### PR TITLE
[LIMS-1700] Make classification values optional

### DIFF
--- a/src/pato/models/response.py
+++ b/src/pato/models/response.py
@@ -434,10 +434,10 @@ class Classification(OrmBaseModel):
     classNumber: int
     classImageFullPath: Optional[str] = None
     particlesPerClass: Optional[int] = None
-    rotationAccuracy: float
-    translationAccuracy: float
-    estimatedResolution: float
-    overallFourierCompleteness: float
+    rotationAccuracy: Optional[float] = None
+    translationAccuracy: Optional[float] = None
+    estimatedResolution: Optional[float] = None
+    overallFourierCompleteness: Optional[float] = None
     classDistribution: Optional[float] = None
     selected: Optional[bool] = None
     bFactorFitIntercept: Optional[float] = None


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1700](https://jira.diamond.ac.uk/browse/LIMS-1700)

**Summary**:

Since sometimes the pipeline fails to insert fourier completeness or estimated resolution values, we must consider these optional instead of throwing errors.

**Changes**:

- Make fourier completeness, estimated resolution, rotation and translation accuracy optional in classification data endpoint
- Check if movie is valid before returning movie information

**To test**:

- Assuming you're pointing at the restored database, send a GET request to https://local-oidc-test.diamond.ac.uk:9000/api/autoProc/110625162/classification?limit=8&page=0&sortBy=particles&classType=2d&excludeUnselected=false, ensure 200 is returned
- Send a GET request to https://local-oidc-test.diamond.ac.uk:9000/api/movies/82012317, ensure 404 is returned
