### PR TITLE
[LIMS-1698] Hide industrial visits from users/staff not included as part of visit

### DIFF
--- a/.github/actions/install_requirements/action.yml
+++ b/.github/actions/install_requirements/action.yml
@@ -1,0 +1,34 @@
+name: Install requirements
+description: Install a version of python then call pip install and report what was installed
+inputs:
+  python-version:
+    description: Python version to install, default is from Dockerfile
+    default: "dev"
+  pip-install:
+    description: Parameters to pass to pip install
+    default: "$([ -f dev-requirements.txt ] && echo '-c dev-requirements.txt') -e .[dev]"
+
+runs:
+  using: composite
+  steps:
+    - name: Get version of python
+      run: |
+        PYTHON_VERSION="${{ inputs.python-version }}"
+        if [ $PYTHON_VERSION == "dev" ]; then
+          PYTHON_VERSION=$(sed -n "s/ARG PYTHON_VERSION=//p" Dockerfile)
+        fi
+        echo "PYTHON_VERSION=$PYTHON_VERSION" >> "$GITHUB_ENV"
+      shell: bash
+
+    - name: Setup python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: Install packages
+      run: pip install ${{ inputs.pip-install }}
+      shell: bash
+
+    - name: Report what was installed
+      run: pip freeze
+      shell: bash

--- a/.github/workflows/_dist.yml
+++ b/.github/workflows/_dist.yml
@@ -2,6 +2,9 @@ name: Create and publish a Docker image
 
 on:
   workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        required: true
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/_dist.yml
+++ b/.github/workflows/_dist.yml
@@ -10,7 +10,6 @@ env:
 jobs:
   build-and-push-image:
     name: Build and push image
-    needs: testing
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/_dist.yml
+++ b/.github/workflows/_dist.yml
@@ -2,9 +2,6 @@ name: Create and publish a Docker image
 
 on:
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/_integration.yml
+++ b/.github/workflows/_integration.yml
@@ -24,9 +24,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[dev]
-      - name: Linting
-        run: |
-          tox -e pre-commit
       - name: Test with pytest
         env:
           CONFIG_PATH: /home/runner/work/pato-backend/pato-backend/config.json

--- a/.github/workflows/_integration.yml
+++ b/.github/workflows/_integration.yml
@@ -6,12 +6,25 @@ on:
       CODECOV_TOKEN:
         required: true
 
+
+
 jobs:
+  get-db-image:
+    runs-on: ubuntu-latest
+    env:
+      BRANCH_NAME: ${{ github.ref_type == 'tag' && 'master' || (github.head_ref || github.ref_name) }}
+    outputs:
+      branch: ${{ steps.clean.outputs.branch }}
+    steps:
+      - id: clean
+        name: "Clean branch name"
+        run: echo "branch=${BRANCH_NAME//\//-}" >> "$GITHUB_OUTPUT"
   test:
     runs-on: ubuntu-latest
+    needs: get-db-image
     services:
       integration-db:
-        image: ghcr.io/diamondlightsource/pato-backend-db:${{ github.ref_type == 'tag' && 'master' || (github.head_ref || github.ref_name) }}
+        image: ghcr.io/diamondlightsource/pato-backend-db:${{ needs.get-db-image.outputs.branch }}
         ports:
           - 3306:3306
     strategy:

--- a/.github/workflows/_integration.yml
+++ b/.github/workflows/_integration.yml
@@ -2,6 +2,9 @@ name: Integration Tests
 
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: true
 
 jobs:
   test:

--- a/.github/workflows/_integration.yml
+++ b/.github/workflows/_integration.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       integration-db:
-        image: ghcr.io/diamondlightsource/pato-backend-db:${{ github.ref_type == 'tag' && 'master' || github.ref_name }}
+        image: ghcr.io/diamondlightsource/pato-backend-db:${{ github.ref_type == 'tag' && 'master' || (github.head_ref || github.ref_name) }}
         ports:
           - 3306:3306
     strategy:

--- a/.github/workflows/_integration.yml
+++ b/.github/workflows/_integration.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       integration-db:
-        image: ghcr.io/diamondlightsource/pato-backend-db:${{ github.ref_type == "tag" && "master" || github.ref_name }}
+        image: ghcr.io/diamondlightsource/pato-backend-db:${{ github.ref_type == 'tag' && 'master' || github.ref_name }}
         ports:
           - 3306:3306
     strategy:

--- a/.github/workflows/_integration.yml
+++ b/.github/workflows/_integration.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       integration-db:
-        image: ghcr.io/diamondlightsource/pato-backend-db:master
+        image: ghcr.io/diamondlightsource/pato-backend-db:${{ github.ref_type == "tag" && "master" || github.ref_name }}
         ports:
           - 3306:3306
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,7 @@ jobs:
     needs: test
     uses: ./.github/workflows/_dist.yml
     permissions:
-      contents: write
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,3 @@ jobs:
     uses: ./.github/workflows/_dist.yml
     permissions:
       contents: write
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     needs: check
     if: needs.check.outputs.branch-pr == ''
     uses: ./.github/workflows/_integration.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   release:
     if: github.ref_type == 'tag'
@@ -26,3 +28,5 @@ jobs:
     uses: ./.github/workflows/_dist.yml
     permissions:
       contents: write
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/db-docker-image.yml
+++ b/.github/workflows/db-docker-image.yml
@@ -10,7 +10,6 @@ on:
   push:
     paths:
       - "database/**"
-    branches: ["master"]
 
 env:
   REGISTRY: ghcr.io

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
       - id: ruff
         name: Run ruff
-        stages: [commit]
+        stages: [pre-commit]
         language: system
         entry: ruff check
         types: [python]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # The devcontainer should use the build target and run as root with podman
 # or docker with user namespaces.
 #
-FROM docker.io/library/python:3.13.2-slim-bullseye as build
+FROM docker.io/library/python:3.13.2-slim-bookworm as build
 
 # Add any system dependencies for the developer/build environment here
 RUN apt-get update && apt-get upgrade -y && \
@@ -40,7 +40,7 @@ RUN pip install --upgrade pip && \
     # and replace with a comment to avoid a zero length asset upload later
     sed -i '/file:/s/^/# Requirements for /' lockfiles/requirements.txt
 
-FROM docker.io/library/python:3.13.2-slim-bullseye as runtime
+FROM docker.io/library/python:3.13.2-slim-bookworm as runtime
 
 # Add apt-get system dependecies for runtime here if needed
 RUN apt-get update && apt-get install -y libmariadb-dev

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,7 @@ As for the JSON configuration file, details are as follows:
     - port: Mesasge queue port 
     - queue: Queue name
     - vhost: Message queue virtual host
+    - consumer_queue: Queue to consume messages from (for notifications)
 - ispyb
     - pool: Connection pool size
     - overflow: Connection pool overflow max size
@@ -43,6 +44,7 @@ As for the JSON configuration file, details are as follows:
     - smtp_server: SMTP server host
     - smtp_port: SMTP port to be used for emailing reports
     - active_session_cutoff: Time, in weeks, to be used as a threshold for determining if a session is active or not, following the end of the first processing pipeline. For example, a session would be considered inactive if there were no new actions for the past 5 weeks, by default.
+    - users_only_on_industrial: Hide industrial session details from staff, only display it to users/staff directly listed as part of that visit
 
 ==========
 Deployment

--- a/config.json
+++ b/config.json
@@ -29,7 +29,8 @@
     "host": "127.0.0.1",
     "port": 5672,
     "queue": "processing_recipe",
-    "vhost": "/"
+    "vhost": "/",
+    "consumer_queue": "pato_notification"
   },
   "ispyb": { "pool": 3, "overflow": 6 },
   "facility": {
@@ -38,7 +39,8 @@
     "smtp_server": "smtp.ac.uk",
     "active_session_cutoff": 5,
     "sample_handling_url": "https://ebic-sample-handling.diamond.ac.uk",
-    "frontend_url": "http://localhost:8080"
+    "frontend_url": "http://localhost:8080",
+    "users_only_on_industrial": false
   },
   "enable_cors": false
 }

--- a/database/data.sql
+++ b/database/data.sql
@@ -310,7 +310,7 @@ CREATE TABLE `AutoProcProgramAttachment` (
   PRIMARY KEY (`autoProcProgramAttachmentId`),
   KEY `AutoProcProgramAttachmentIdx1` (`autoProcProgramId`),
   CONSTRAINT `AutoProcProgramAttachmentFk1` FOREIGN KEY (`autoProcProgramId`) REFERENCES `AutoProcProgram` (`autoProcProgramId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=1037272 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=1037286 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -928,7 +928,7 @@ CREATE TABLE `BLSample` (
   CONSTRAINT `BLSample_ibfk_1` FOREIGN KEY (`containerId`) REFERENCES `Container` (`containerId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `BLSample_ibfk_2` FOREIGN KEY (`crystalId`) REFERENCES `Crystal` (`crystalId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `BLSample_ibfk_3` FOREIGN KEY (`diffractionPlanId`) REFERENCES `DiffractionPlan` (`diffractionPlanId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=398936 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=400092 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1482,7 +1482,7 @@ CREATE TABLE `BLSession` (
   CONSTRAINT `BLSession_fk_beamCalendarId` FOREIGN KEY (`beamCalendarId`) REFERENCES `BeamCalendar` (`beamCalendarId`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `BLSession_ibfk_1` FOREIGN KEY (`proposalId`) REFERENCES `Proposal` (`proposalId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `BLSession_ibfk_2` FOREIGN KEY (`beamLineSetupId`) REFERENCES `BeamLineSetup` (`beamLineSetupId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=27464133 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=27464173 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1501,7 +1501,8 @@ INSERT INTO `BLSession` VALUES
 (339535,NULL,37027,NULL,'2018-03-27 09:00:00','2018-07-27 09:00:00','i02-2',NULL,NULL,NULL,NULL,'2018-04-05 15:48:37',99,NULL,'0000-00-00 00:00:00',NULL,0,NULL,0),
 (27464088,NULL,60858,NULL,'2022-10-21 09:00:00','2023-10-31 09:00:00','m12',0,NULL,NULL,NULL,'2021-12-14 14:51:19',5,NULL,'0000-00-00 00:00:00',NULL,0,NULL,0),
 (27464089,NULL,60858,NULL,'2022-10-21 09:00:00','2022-10-31 09:00:00','m12',0,NULL,NULL,NULL,'2021-12-14 14:51:19',6,NULL,'0000-00-00 00:00:00',NULL,0,NULL,0),
-(27464090,NULL,1000028,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'2024-12-09 16:57:15',NULL,NULL,'0000-00-00 00:00:00',NULL,0,NULL,0);
+(27464090,NULL,1000028,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,'2024-12-09 16:57:15',NULL,NULL,'0000-00-00 00:00:00',NULL,0,NULL,0),
+(27464172,NULL,1000327,NULL,NULL,NULL,'m12',NULL,NULL,NULL,NULL,'2025-04-24 10:11:06',1,NULL,'0000-00-00 00:00:00',NULL,0,NULL,0);
 /*!40000 ALTER TABLE `BLSession` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -2180,7 +2181,7 @@ CREATE TABLE `Container` (
   CONSTRAINT `Container_ibfk8` FOREIGN KEY (`containerRegistryId`) REFERENCES `ContainerRegistry` (`containerRegistryId`),
   CONSTRAINT `Container_ibfk9` FOREIGN KEY (`priorityPipelineId`) REFERENCES `ProcessingPipeline` (`processingPipelineId`),
   CONSTRAINT `Container_ibfk_1` FOREIGN KEY (`dewarId`) REFERENCES `Dewar` (`dewarId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=35106 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=36058 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2379,7 +2380,7 @@ CREATE TABLE `ContainerRegistry` (
   `comments` varchar(255) DEFAULT NULL,
   `recordTimestamp` datetime DEFAULT current_timestamp(),
   PRIMARY KEY (`containerRegistryId`)
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2391,7 +2392,8 @@ LOCK TABLES `ContainerRegistry` WRITE;
 INSERT INTO `ContainerRegistry` VALUES
 (4,'DLS-0001',NULL,'2017-09-21 10:01:07'),
 (5,'VMXiSim-001',NULL,'2019-03-22 11:48:43'),
-(6,'DLS-0002',NULL,'2024-12-09 16:58:17');
+(6,'DLS-0002',NULL,'2024-12-09 16:58:17'),
+(7,'DLS-0003',NULL,'2017-09-21 10:01:07');
 /*!40000 ALTER TABLE `ContainerRegistry` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -2415,7 +2417,7 @@ CREATE TABLE `ContainerRegistry_has_Proposal` (
   CONSTRAINT `ContainerRegistry_has_Proposal_ibfk1` FOREIGN KEY (`containerRegistryId`) REFERENCES `ContainerRegistry` (`containerRegistryId`),
   CONSTRAINT `ContainerRegistry_has_Proposal_ibfk2` FOREIGN KEY (`proposalId`) REFERENCES `Proposal` (`proposalId`),
   CONSTRAINT `ContainerRegistry_has_Proposal_ibfk3` FOREIGN KEY (`personId`) REFERENCES `Person` (`personId`)
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2426,7 +2428,8 @@ LOCK TABLES `ContainerRegistry_has_Proposal` WRITE;
 /*!40000 ALTER TABLE `ContainerRegistry_has_Proposal` DISABLE KEYS */;
 INSERT INTO `ContainerRegistry_has_Proposal` VALUES
 (1,4,141666,NULL,'2023-09-14 09:00:51'),
-(2,6,1000028,NULL,'2024-12-09 16:58:05');
+(2,6,1000028,NULL,'2024-12-09 16:58:05'),
+(4,7,141666,NULL,'2023-09-14 09:00:51');
 /*!40000 ALTER TABLE `ContainerRegistry_has_Proposal` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -2626,7 +2629,7 @@ CREATE TABLE `Crystal` (
   KEY `Crystal_FKIndex2` (`diffractionPlanId`),
   CONSTRAINT `Crystal_ibfk_1` FOREIGN KEY (`proteinId`) REFERENCES `Protein` (`proteinId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `Crystal_ibfk_2` FOREIGN KEY (`diffractionPlanId`) REFERENCES `DiffractionPlan` (`diffractionPlanId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=333309 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=334193 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2879,7 +2882,7 @@ CREATE TABLE `DataCollection` (
   CONSTRAINT `DataCollection_ibfk_6` FOREIGN KEY (`startPositionId`) REFERENCES `MotorPosition` (`motorPositionId`),
   CONSTRAINT `DataCollection_ibfk_7` FOREIGN KEY (`endPositionId`) REFERENCES `MotorPosition` (`motorPositionId`),
   CONSTRAINT `DataCollection_ibfk_8` FOREIGN KEY (`blSubSampleId`) REFERENCES `BLSubSample` (`blSubSampleId`)
-) ENGINE=InnoDB AUTO_INCREMENT=6017786 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=6017842 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2996,7 +2999,7 @@ CREATE TABLE `DataCollectionGroup` (
   CONSTRAINT `DataCollectionGroup_ibfk_1` FOREIGN KEY (`blSampleId`) REFERENCES `BLSample` (`blSampleId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `DataCollectionGroup_ibfk_2` FOREIGN KEY (`sessionId`) REFERENCES `BLSession` (`sessionId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `DataCollectionGroup_ibfk_4` FOREIGN KEY (`experimentTypeId`) REFERENCES `ExperimentType` (`experimentTypeId`)
-) ENGINE=InnoDB AUTO_INCREMENT=5441044 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci COMMENT='a dataCollectionGroup is a group of dataCollection for a spe';
+) ENGINE=InnoDB AUTO_INCREMENT=5441099 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci COMMENT='a dataCollectionGroup is a group of dataCollection for a spe';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3141,7 +3144,7 @@ CREATE TABLE `Dewar` (
   KEY `Dewar_FKIndexStatus` (`dewarStatus`),
   CONSTRAINT `Dewar_fk_firstExperimentId` FOREIGN KEY (`firstExperimentId`) REFERENCES `BLSession` (`sessionId`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `Dewar_ibfk_1` FOREIGN KEY (`shippingId`) REFERENCES `Shipping` (`shippingId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=8690 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=9695 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3236,7 +3239,7 @@ CREATE TABLE `DewarRegistry` (
   KEY `DewarRegistry_ibfk_2` (`labContactId`),
   CONSTRAINT `DewarRegistry_ibfk_1` FOREIGN KEY (`proposalId`) REFERENCES `Proposal` (`proposalId`) ON DELETE NO ACTION ON UPDATE CASCADE,
   CONSTRAINT `DewarRegistry_ibfk_2` FOREIGN KEY (`labContactId`) REFERENCES `LabContact` (`labContactId`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=211 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=251 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3247,7 +3250,8 @@ LOCK TABLES `DewarRegistry` WRITE;
 /*!40000 ALTER TABLE `DewarRegistry` DISABLE KEYS */;
 INSERT INTO `DewarRegistry` VALUES
 (1,'DLS-EM-0000',141666,NULL,NULL,'2023-09-14 09:19:21',NULL),
-(2,'DLS-EM-0001',37027,NULL,NULL,'2023-09-14 09:19:21',NULL);
+(2,'DLS-EM-0001',37027,NULL,NULL,'2023-09-14 09:19:21',NULL),
+(217,'DLS-EM-0002',141666,NULL,NULL,'2023-09-14 09:19:21',NULL);
 /*!40000 ALTER TABLE `DewarRegistry` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -3274,7 +3278,7 @@ CREATE TABLE `DewarRegistry_has_Proposal` (
   CONSTRAINT `DewarRegistry_has_Proposal_ibfk2` FOREIGN KEY (`proposalId`) REFERENCES `Proposal` (`proposalId`),
   CONSTRAINT `DewarRegistry_has_Proposal_ibfk3` FOREIGN KEY (`personId`) REFERENCES `Person` (`personId`),
   CONSTRAINT `DewarRegistry_has_Proposal_ibfk4` FOREIGN KEY (`labContactId`) REFERENCES `LabContact` (`labContactId`) ON DELETE NO ACTION ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=134 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=161 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3284,7 +3288,8 @@ CREATE TABLE `DewarRegistry_has_Proposal` (
 LOCK TABLES `DewarRegistry_has_Proposal` WRITE;
 /*!40000 ALTER TABLE `DewarRegistry_has_Proposal` DISABLE KEYS */;
 INSERT INTO `DewarRegistry_has_Proposal` VALUES
-(1,1,141666,NULL,'2023-09-14 09:22:50',NULL);
+(1,1,141666,NULL,'2023-09-14 09:22:50',NULL),
+(138,217,141666,NULL,'2023-09-14 09:22:50',NULL);
 /*!40000 ALTER TABLE `DewarRegistry_has_Proposal` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -3424,7 +3429,7 @@ CREATE TABLE `DiffractionPlan` (
   CONSTRAINT `DiffractionPlan_ibfk1` FOREIGN KEY (`presetForProposalId`) REFERENCES `Proposal` (`proposalId`),
   CONSTRAINT `DiffractionPlan_ibfk2` FOREIGN KEY (`purificationColumnId`) REFERENCES `PurificationColumn` (`purificationColumnId`),
   CONSTRAINT `DiffractionPlan_ibfk3` FOREIGN KEY (`experimentTypeId`) REFERENCES `ExperimentType` (`experimentTypeId`)
-) ENGINE=InnoDB AUTO_INCREMENT=197793 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=199201 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3837,7 +3842,7 @@ CREATE TABLE `GridInfo` (
   KEY `GridInfo_fk_dataCollectionId` (`dataCollectionId`),
   CONSTRAINT `GridInfo_fk_dataCollectionId` FOREIGN KEY (`dataCollectionId`) REFERENCES `DataCollection` (`dataCollectionId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `GridInfo_ibfk_2` FOREIGN KEY (`dataCollectionGroupId`) REFERENCES `DataCollectionGroup` (`dataCollectionGroupId`)
-) ENGINE=InnoDB AUTO_INCREMENT=1281433 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=1281461 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -4889,7 +4894,7 @@ CREATE TABLE `Person` (
   KEY `Person_FKIndexFamilyName` (`familyName`),
   KEY `siteId` (`siteId`),
   CONSTRAINT `Person_ibfk_1` FOREIGN KEY (`laboratoryId`) REFERENCES `Laboratory` (`laboratoryId`) ON DELETE NO ACTION ON UPDATE NO ACTION
-) ENGINE=InnoDB AUTO_INCREMENT=46409 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=46437 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -4908,7 +4913,9 @@ INSERT INTO `Person` VALUES
 (18660,NULL,NULL,NULL,'Moss','Stirling','Dr',NULL,NULL,'em_admin',NULL,'2022-10-21 09:00:00',NULL,NULL),
 (46266,NULL,NULL,NULL,NULL,NULL,'User',NULL,NULL,NULL,NULL,'2016-03-16 15:53:55',NULL,NULL),
 (46269,NULL,NULL,NULL,NULL,NULL,'User',NULL,NULL,NULL,NULL,'2016-03-16 15:59:22',NULL,NULL),
-(46270,NULL,NULL,NULL,'Hill','Damon','Mr',NULL,NULL,'session_no_proposal',NULL,'2016-03-16 15:59:22',NULL,'?�_dWEb��');
+(46270,NULL,NULL,NULL,'Hill','Damon','Mr',NULL,NULL,'session_no_proposal',NULL,'2016-03-16 15:59:22',NULL,'?�_dWEb��'),
+(46435,NULL,NULL,NULL,'Villeneuve','Giles','Dr',NULL,NULL,'industrial',NULL,'2025-04-24 11:16:02',NULL,NULL),
+(46436,NULL,NULL,NULL,'Hakkinen','Mika','Mr',NULL,NULL,'abc12345',NULL,'2025-04-24 12:27:17',NULL,NULL);
 /*!40000 ALTER TABLE `Person` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -5162,7 +5169,7 @@ CREATE TABLE `Position` (
   PRIMARY KEY (`positionId`),
   KEY `Position_FKIndex1` (`relativePositionId`),
   CONSTRAINT `Position_relativePositionfk_1` FOREIGN KEY (`relativePositionId`) REFERENCES `Position` (`positionId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=196 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=224 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -5284,7 +5291,7 @@ CREATE TABLE `ProcessingJob` (
   PRIMARY KEY (`processingJobId`),
   KEY `ProcessingJob_ibfk1` (`dataCollectionId`),
   CONSTRAINT `ProcessingJob_ibfk1` FOREIGN KEY (`dataCollectionId`) REFERENCES `DataCollection` (`dataCollectionId`)
-) ENGINE=InnoDB AUTO_INCREMENT=3711 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci COMMENT='From this we get both job times and lag times';
+) ENGINE=InnoDB AUTO_INCREMENT=3972 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci COMMENT='From this we get both job times and lag times';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -5379,7 +5386,7 @@ CREATE TABLE `ProcessingJobParameter` (
   KEY `ProcessingJobParameter_ibfk1` (`processingJobId`),
   KEY `ProcessingJobParameter_idx_paramKey_procJobId` (`parameterKey`,`processingJobId`),
   CONSTRAINT `ProcessingJobParameter_ibfk1` FOREIGN KEY (`processingJobId`) REFERENCES `ProcessingJob` (`processingJobId`)
-) ENGINE=InnoDB AUTO_INCREMENT=24255 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=27155 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -5747,7 +5754,7 @@ CREATE TABLE `Proposal` (
   UNIQUE KEY `Proposal_FKIndexCodeNumber` (`proposalCode`,`proposalNumber`),
   KEY `Proposal_FKIndex1` (`personId`),
   CONSTRAINT `Proposal_ibfk_1` FOREIGN KEY (`personId`) REFERENCES `Person` (`personId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=1000287 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=1000328 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -5762,7 +5769,8 @@ INSERT INTO `Proposal` VALUES
 (141666,46266,'Test Proposal cm-0001','cm','1','2016-03-16 16:01:34',NULL,NULL,'Open'),
 (999999,1,'Test Proposal bi-0001','bi','8','2021-12-14 14:50:02',NULL,NULL,'Open'),
 (1000024,1,'Proposal with shipment','cm','33333','2024-12-09 16:54:31',NULL,NULL,'Open'),
-(1000028,1,'Proposal with null session','cm','22222','2024-12-09 16:56:33',NULL,NULL,'Open');
+(1000028,1,'Proposal with null session','cm','22222','2024-12-09 16:56:33',NULL,NULL,'Open'),
+(1000327,46435,'Industrial proposal','in','1','2025-04-24 10:10:43',NULL,NULL,'Open');
 /*!40000 ALTER TABLE `Proposal` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -5783,7 +5791,7 @@ CREATE TABLE `ProposalHasPerson` (
   KEY `fk_ProposalHasPerson_Personal` (`personId`),
   CONSTRAINT `fk_ProposalHasPerson_Personal` FOREIGN KEY (`personId`) REFERENCES `Person` (`personId`) ON DELETE NO ACTION ON UPDATE NO ACTION,
   CONSTRAINT `fk_ProposalHasPerson_Proposal` FOREIGN KEY (`proposalId`) REFERENCES `Proposal` (`proposalId`) ON DELETE NO ACTION ON UPDATE NO ACTION
-) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -5795,7 +5803,8 @@ LOCK TABLES `ProposalHasPerson` WRITE;
 INSERT INTO `ProposalHasPerson` VALUES
 (4,37027,1,'Principal Investigator'),
 (5,60858,18600,'Principal Investigator'),
-(6,1000028,1,'Principal Investigator');
+(6,1000028,1,'Principal Investigator'),
+(7,1000327,46435,'Principal Investigator');
 /*!40000 ALTER TABLE `ProposalHasPerson` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -5838,7 +5847,7 @@ CREATE TABLE `Protein` (
   CONSTRAINT `Protein_ibfk_1` FOREIGN KEY (`proposalId`) REFERENCES `Proposal` (`proposalId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `protein_fk3` FOREIGN KEY (`componentTypeId`) REFERENCES `ComponentType` (`componentTypeId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `protein_fk4` FOREIGN KEY (`concentrationTypeId`) REFERENCES `ConcentrationType` (`concentrationTypeId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=123666 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=123692 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -5848,8 +5857,8 @@ CREATE TABLE `Protein` (
 LOCK TABLES `Protein` WRITE;
 /*!40000 ALTER TABLE `Protein` DISABLE KEYS */;
 INSERT INTO `Protein` VALUES
-(4380,141666,'Protein 01','PRT-01',NULL,1,1,NULL,NULL,NULL,NULL,'2016-03-17 15:57:52',0,NULL,NULL,NULL,NULL,0,NULL,NULL,NULL,NULL),
-(4383,141666,'Protein 02','PRT-02',NULL,1,1,NULL,NULL,NULL,NULL,'2016-03-17 16:02:07',0,NULL,NULL,NULL,NULL,0,NULL,NULL,NULL,NULL),
+(4380,141666,'Protein 01','PRT-01',NULL,1,1,'GREEN',NULL,NULL,NULL,'2016-03-17 15:57:52',0,NULL,NULL,NULL,NULL,0,NULL,NULL,NULL,NULL),
+(4383,141666,'Protein 02','PRT-02',NULL,1,1,'GREEN',NULL,NULL,NULL,'2016-03-17 16:02:07',0,NULL,NULL,NULL,NULL,0,NULL,NULL,NULL,NULL),
 (4386,141666,'Protein 03','PRT-03',NULL,1,1,NULL,NULL,NULL,NULL,'2016-03-17 16:02:07',0,NULL,NULL,NULL,NULL,0,NULL,NULL,NULL,NULL),
 (4389,141666,'Protein 04','PRT-04',NULL,1,1,NULL,NULL,NULL,NULL,'2016-03-17 16:02:07',0,NULL,NULL,NULL,NULL,0,NULL,NULL,NULL,NULL),
 (4392,141666,'Protein 05','PRT-05',NULL,1,1,NULL,NULL,NULL,NULL,'2016-03-17 16:02:07',0,NULL,NULL,NULL,NULL,0,NULL,NULL,NULL,NULL),
@@ -5993,7 +6002,7 @@ CREATE TABLE `RobotAction` (
   KEY `RobotAction_FK2` (`blsampleId`),
   CONSTRAINT `RobotAction_FK1` FOREIGN KEY (`blsessionId`) REFERENCES `BLSession` (`sessionId`),
   CONSTRAINT `RobotAction_FK2` FOREIGN KEY (`blsampleId`) REFERENCES `BLSample` (`blSampleId`)
-) ENGINE=InnoDB AUTO_INCREMENT=366 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci COMMENT='Robot actions as reported by GDA';
+) ENGINE=InnoDB AUTO_INCREMENT=392 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci COMMENT='Robot actions as reported by GDA';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -7081,7 +7090,7 @@ CREATE TABLE `SessionType` (
   PRIMARY KEY (`sessionTypeId`),
   KEY `SessionType_FKIndex1` (`sessionId`),
   CONSTRAINT `SessionType_ibfk_1` FOREIGN KEY (`sessionId`) REFERENCES `BLSession` (`sessionId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=30 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=56 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -7122,8 +7131,10 @@ INSERT INTO `Session_has_Person` VALUES
 (55167,1,'Co-Investigator',0),
 (55168,1,'Co-Investigator',0),
 (27464088,46270,'Data Access',0),
+(27464088,46436,'Local Contact',0),
 (27464089,18600,'Principal Investigator',0),
-(27464090,1,'Local Contact',0);
+(27464090,1,'Local Contact',0),
+(27464172,46435,'Principal Investigator',0);
 /*!40000 ALTER TABLE `Session_has_Person` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -7182,7 +7193,7 @@ CREATE TABLE `Shipping` (
   CONSTRAINT `Shipping_ibfk_2` FOREIGN KEY (`sendingLabContactId`) REFERENCES `LabContact` (`labContactId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `Shipping_ibfk_3` FOREIGN KEY (`returnLabContactId`) REFERENCES `LabContact` (`labContactId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `Shipping_ibfk_4` FOREIGN KEY (`deliveryAgent_flightCodePersonId`) REFERENCES `Person` (`personId`)
-) ENGINE=InnoDB AUTO_INCREMENT=7353 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=8343 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -7936,7 +7947,7 @@ CREATE TABLE `XFEFluorescenceSpectrum` (
   CONSTRAINT `XFE_ibfk_1` FOREIGN KEY (`sessionId`) REFERENCES `BLSession` (`sessionId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `XFE_ibfk_2` FOREIGN KEY (`blSampleId`) REFERENCES `BLSample` (`blSampleId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `XFE_ibfk_3` FOREIGN KEY (`blSubSampleId`) REFERENCES `BLSubSample` (`blSubSampleId`)
-) ENGINE=InnoDB AUTO_INCREMENT=2196 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2222 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -8275,4 +8286,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2025-04-23  9:38:30
+-- Dump completed on 2025-04-24 13:58:33

--- a/database/data.sql
+++ b/database/data.sql
@@ -2879,7 +2879,7 @@ CREATE TABLE `DataCollection` (
   CONSTRAINT `DataCollection_ibfk_6` FOREIGN KEY (`startPositionId`) REFERENCES `MotorPosition` (`motorPositionId`),
   CONSTRAINT `DataCollection_ibfk_7` FOREIGN KEY (`endPositionId`) REFERENCES `MotorPosition` (`motorPositionId`),
   CONSTRAINT `DataCollection_ibfk_8` FOREIGN KEY (`blSubSampleId`) REFERENCES `BLSubSample` (`blSubSampleId`)
-) ENGINE=InnoDB AUTO_INCREMENT=6017785 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=6017786 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2996,7 +2996,7 @@ CREATE TABLE `DataCollectionGroup` (
   CONSTRAINT `DataCollectionGroup_ibfk_1` FOREIGN KEY (`blSampleId`) REFERENCES `BLSample` (`blSampleId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `DataCollectionGroup_ibfk_2` FOREIGN KEY (`sessionId`) REFERENCES `BLSession` (`sessionId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `DataCollectionGroup_ibfk_4` FOREIGN KEY (`experimentTypeId`) REFERENCES `ExperimentType` (`experimentTypeId`)
-) ENGINE=InnoDB AUTO_INCREMENT=5441043 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci COMMENT='a dataCollectionGroup is a group of dataCollection for a spe';
+) ENGINE=InnoDB AUTO_INCREMENT=5441044 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci COMMENT='a dataCollectionGroup is a group of dataCollection for a spe';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -5284,7 +5284,7 @@ CREATE TABLE `ProcessingJob` (
   PRIMARY KEY (`processingJobId`),
   KEY `ProcessingJob_ibfk1` (`dataCollectionId`),
   CONSTRAINT `ProcessingJob_ibfk1` FOREIGN KEY (`dataCollectionId`) REFERENCES `DataCollection` (`dataCollectionId`)
-) ENGINE=InnoDB AUTO_INCREMENT=3702 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci COMMENT='From this we get both job times and lag times';
+) ENGINE=InnoDB AUTO_INCREMENT=3711 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci COMMENT='From this we get both job times and lag times';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -5379,7 +5379,7 @@ CREATE TABLE `ProcessingJobParameter` (
   KEY `ProcessingJobParameter_ibfk1` (`processingJobId`),
   KEY `ProcessingJobParameter_idx_paramKey_procJobId` (`parameterKey`,`processingJobId`),
   CONSTRAINT `ProcessingJobParameter_ibfk1` FOREIGN KEY (`processingJobId`) REFERENCES `ProcessingJob` (`processingJobId`)
-) ENGINE=InnoDB AUTO_INCREMENT=24155 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=24255 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -8275,4 +8275,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2025-03-20 11:49:05
+-- Dump completed on 2025-04-23  9:38:30

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,16 +16,16 @@ description = "PATO's backend"
 dependencies = [
     "python-multipart~=0.0.9",
     "pika~=1.3.2",
-    "SQLAlchemy~=2.0.34",
-    "fastapi~=0.115.5",
-    "uvicorn[standard]~=0.30.1",
+    "SQLAlchemy~=2.0.40",
+    "fastapi~=0.115.12",
+    "uvicorn[standard]~=0.34.2",
     "requests~=2.32.3",
-    "mysqlclient~=2.2.4",
+    "mysqlclient~=2.2.7",
     "mysql-connector-python~=8.2.0",
-    "pydantic[email]~=2.9.2",
-    "fpdf2~=2.8.2",
+    "pydantic[email]~=2.11.3",
+    "fpdf2~=2.8.3",
     "types-requests",
-    "lims-utils~=0.4.3"
+    "lims-utils~=0.4.4"
 ]
 dynamic = ["version"]
 license.file = "LICENSE"
@@ -100,7 +100,7 @@ allowlist_externals =
     # sphinx-build
     # sphinx-autobuild
 commands =
-    pytest: pytest tests --cov=pato --cov-report term --cov-report xml:cov.xml {posargs} -s
+    pytest: pytest tests --cov=pato --cov-report term --cov-report xml:cov.xml {posargs}
     mypy: mypy src tests {posargs}
     pre-commit: pre-commit run --all-files {posargs}
 setenv = 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "pydantic[email]~=2.9.2",
     "fpdf2~=2.8.2",
     "types-requests",
-    "lims-utils~=0.4.1"
+    "lims-utils~=0.4.3"
 ]
 dynamic = ["version"]
 license.file = "LICENSE"

--- a/src/pato/auth/micro.py
+++ b/src/pato/auth/micro.py
@@ -42,11 +42,12 @@ class User(GenericUser):
         super().__init__(**user)
 
 
-def _check_perms(data_id: str | int, endpoint: str, token: str, options: str = ""):
+def _check_perms(data_id: str | int, endpoint: str, token: str, options: dict[str, str | int | bool] = {}):
     response = requests.get(
         "".join(
-            [Config.auth.endpoint, "permission/", endpoint, "/", str(data_id), options]
+            [Config.auth.endpoint, "permission/", endpoint, "/", str(data_id)]
         ),
+        params={**options, "usersOnly": True},
         headers={"Authorization": f"Bearer {token}"},
     )
 
@@ -117,7 +118,7 @@ class Permissions(GenericPermissions):
                 detail="Data collection group not found",
             )
 
-        _check_perms(session_id, "session", token.credentials, "?useId=true")
+        _check_perms(session_id, "session", token.credentials, {"useId": True})
 
         return groupId
 
@@ -140,7 +141,7 @@ class Permissions(GenericPermissions):
                 detail="Grid square not found",
             )
 
-        _check_perms(session_id, "session", token.credentials, "?useId=true")
+        _check_perms(session_id, "session", token.credentials, {"useId": True})
 
         return gridSquareId
 
@@ -164,6 +165,6 @@ class Permissions(GenericPermissions):
                 detail="Foil hole not found",
             )
 
-        _check_perms(session_id, "session", token.credentials, "?useId=true")
+        _check_perms(session_id, "session", token.credentials, {"useId": True})
 
         return foilHoleId

--- a/src/pato/auth/micro.py
+++ b/src/pato/auth/micro.py
@@ -47,7 +47,7 @@ def _check_perms(data_id: str | int, endpoint: str, token: str, options: dict[st
         "".join(
             [Config.auth.endpoint, "permission/", endpoint, "/", str(data_id)]
         ),
-        params={**options, "usersOnly": True},
+        params={**options, "usersOnly": Config.facility.users_only_on_industrial},
         headers={"Authorization": f"Bearer {token}"},
     )
 

--- a/src/pato/crud/autoproc.py
+++ b/src/pato/crud/autoproc.py
@@ -27,7 +27,7 @@ from ..models.response import (
     ItemList,
     TomogramResponse,
 )
-from ..utils.database import db, paginate, unravel
+from ..utils.database import db, unravel
 from ..utils.generic import validate_path
 
 
@@ -57,7 +57,7 @@ def get_motion_correction(limit: int, page: int, autoProcId: int) -> Paged[FullM
         .order_by(MotionCorrection.imageNumber)
     )
 
-    return paginate(query, limit, page)
+    return db.paginate(query, limit, page)
 
 
 def get_ctf(autoProcId: int):
@@ -94,7 +94,7 @@ def get_particle_picker(autoProcId: int, filterNull: bool, limit: int, page: int
         .order_by(MotionCorrection.imageNumber)
     )
 
-    return paginate(query, limit, page)
+    return db.paginate(query, limit, page)
 
 
 _2d_ordering: dict[str, UnaryExpression] = {
@@ -162,7 +162,7 @@ def get_classification(
     if excludeUnselected:
         query = query.filter(ParticleClassification.selected != 0)
 
-    return paginate(query, limit, page)
+    return db.paginate(query, limit, page)
 
 
 @validate_path

--- a/src/pato/crud/collections.py
+++ b/src/pato/crud/collections.py
@@ -41,7 +41,7 @@ from ..models.response import (
     ProcessingJobResponse,
     TomogramFullResponse,
 )
-from ..utils.database import db, paginate
+from ..utils.database import db
 from ..utils.generic import check_session_active, parse_count
 from ..utils.pika import PikaPublisher
 
@@ -102,7 +102,7 @@ def get_tomograms(
         .order_by(ProcessingJob.processingJobId.desc())
     )
 
-    return paginate(query, limit, page, slow_count=False)
+    return db.paginate(query, limit, page, slow_count=False)
 
 
 def get_motion_correction(limit: int, page: int, collectionId: int) -> Paged[FullMovie]:
@@ -115,7 +115,7 @@ def get_motion_correction(limit: int, page: int, collectionId: int) -> Paged[Ful
         .group_by(Movie.movieId)
     )
 
-    return paginate(query, limit, page, slow_count=True)
+    return db.paginate(query, limit, page, slow_count=True)
 
 
 def initiate_reprocessing_tomogram(
@@ -310,7 +310,7 @@ def get_processing_jobs(
         )
     )
 
-    return paginate(query, limit, page, slow_count=False)
+    return db.paginate(query, limit, page, slow_count=False)
 
 
 def _with_ctf_joins(query: Select, collectionId: int):

--- a/src/pato/crud/groups.py
+++ b/src/pato/crud/groups.py
@@ -41,7 +41,7 @@ def get_collection_group(group_id: int):
         .filter(DataCollectionGroup.dataCollectionGroupId == group_id)
     ).one()
 
-
+# TODO: make session and proposal required
 def get_collection_groups(
     limit: int,
     page: int,
@@ -96,9 +96,9 @@ def get_collection_groups(
                     db.session.execute(session_id_query).all()
                 )
             )
-    return db.paginate(check_session(query, user), limit, page, slow_count=True)
+    return db.paginate(check_session(query, user, join_proposal=(not proposal)), limit, page, slow_count=True)
 
-
+# TODO: make group ID required
 def get_collections(
     limit: int,
     page: int,
@@ -132,6 +132,7 @@ def get_collections(
     sub_with_row = check_session(
         base_sub_query,
         user,
+        join_proposal=True
     )
 
     if groupId is not None:

--- a/src/pato/crud/proposals.py
+++ b/src/pato/crud/proposals.py
@@ -6,7 +6,7 @@ from sqlalchemy import or_, select
 
 from ..models.response import ProposalResponse
 from ..utils.auth import check_proposal
-from ..utils.database import paginate
+from ..utils.database import db
 
 
 def get_proposals(
@@ -31,4 +31,4 @@ def get_proposals(
         .order_by(BLSession.startDate.desc())
     )
 
-    return paginate(check_proposal(query, user), limit, page)
+    return db.paginate(check_proposal(query, user), limit, page)

--- a/src/pato/crud/sessions.py
+++ b/src/pato/crud/sessions.py
@@ -128,7 +128,7 @@ def get_sessions(
             )
         )
 
-    query = check_session(query, user)
+    query = check_session(query, user, join_proposal=(proposal is None))
 
     if countCollections:
         query = query.join(

--- a/src/pato/crud/sessions.py
+++ b/src/pato/crud/sessions.py
@@ -14,7 +14,7 @@ from ..models.collections import DataCollectionCreationParameters
 from ..models.response import SessionAllowsReprocessing, SessionResponse
 from ..utils.auth import check_session
 from ..utils.config import Config
-from ..utils.database import db, paginate, unravel
+from ..utils.database import db, unravel
 from ..utils.generic import ProposalReference, check_session_active, parse_proposal
 
 HDF5_FILE_SIGNATURE = b"\x89\x48\x44\x46\x0d\x0a\x1a\x0a"
@@ -137,7 +137,7 @@ def get_sessions(
             isouter=True,
         ).group_by(BLSession.visit_number, BLSession.proposalId)
 
-    return paginate(query, limit, page)
+    return db.paginate(query, limit, page)
 
 
 def get_session(proposalReference: ProposalReference):

--- a/src/pato/crud/tomograms.py
+++ b/src/pato/crud/tomograms.py
@@ -19,7 +19,7 @@ from ..models.response import (
     FullMovieWithTilt,
     ItemList,
 )
-from ..utils.database import db, paginate
+from ..utils.database import db
 from ..utils.generic import MovieType, parse_json_file, validate_path
 
 
@@ -123,7 +123,7 @@ def get_motion_correction(
         .order_by(TiltImageAlignment.refinedTiltAngle)
     )
 
-    motion = dict(paginate(query, limit, page))
+    motion = dict(db.paginate(query, limit, page))
 
     raw_total = db.session.execute(
         select(

--- a/src/pato/models/response.py
+++ b/src/pato/models/response.py
@@ -434,10 +434,10 @@ class Classification(OrmBaseModel):
     classNumber: int
     classImageFullPath: Optional[str] = None
     particlesPerClass: Optional[int] = None
-    rotationAccuracy: float
-    translationAccuracy: float
-    estimatedResolution: float
-    overallFourierCompleteness: float
+    rotationAccuracy: Optional[float] = None
+    translationAccuracy: Optional[float] = None
+    estimatedResolution: Optional[float] = None
+    overallFourierCompleteness: Optional[float] = None
     classDistribution: Optional[float] = None
     selected: Optional[bool] = None
     bFactorFitIntercept: Optional[float] = None

--- a/src/pato/utils/auth.py
+++ b/src/pato/utils/auth.py
@@ -24,17 +24,13 @@ def _get_staff_perms(user: GenericUser):
     Returns:
         Additional SQL conditions based on user permissions, or None if user has no extra permissions"""
     allowed_beamlines = get_allowed_beamlines(user.permissions)
-    user_is_admin = is_admin(user.permissions)
 
-    if allowed_beamlines or user_is_admin:
+    if allowed_beamlines:
         if Config.facility.users_only_on_industrial:
             # We only want to restrict industrial visits to listed users
             return and_(
                 Proposal.proposalCode.not_in(["ic", "il", "in", "sw"]),
-                or_(
-                    BLSession.beamLineName.in_(allowed_beamlines),
-                    user_is_admin,
-                ),
+                BLSession.beamLineName.in_(allowed_beamlines),
             )
 
         return BLSession.beamLineName.in_(allowed_beamlines)
@@ -50,7 +46,7 @@ def check_session(query: Select, user: GenericUser, join_proposal: bool = False)
 
     Returns
         Modified query"""
-    if not Config.facility.users_only_on_industrial and is_admin(user.permissions):
+    if is_admin(user.permissions):
         return query
 
     or_expressions = [SessionHasPerson.personId == user.id]
@@ -84,7 +80,7 @@ def check_proposal(query: Select, user: GenericUser):
 
     Returns
         Modified query"""
-    if not Config.facility.users_only_on_industrial and is_admin(user.permissions):
+    if is_admin(user.permissions):
         return query
 
     or_expressions = [ProposalHasPerson.personId == user.id]

--- a/src/pato/utils/auth.py
+++ b/src/pato/utils/auth.py
@@ -1,6 +1,6 @@
 from lims_utils.auth import GenericUser
 from lims_utils.tables import BLSession, Proposal, ProposalHasPerson, SessionHasPerson
-from sqlalchemy import Select, or_
+from sqlalchemy import Select, and_, or_
 
 from ..auth import is_admin
 from .config import Config
@@ -15,23 +15,55 @@ def get_allowed_beamlines(perms: list[int]) -> set[str]:
 
     return allowed_beamlines
 
+def _get_staff_perms(user: GenericUser):
+    """Get the appropriate set of beamline-related permissions based on an user's user groups
+
+    Args:
+        user: User to check permissions for
+
+    Returns:
+        Additional SQL conditions based on user permissions, or None if user has no extra permissions"""
+    allowed_beamlines = get_allowed_beamlines(user.permissions)
+    user_is_admin = is_admin(user.permissions)
+
+    if allowed_beamlines or user_is_admin:
+        if Config.facility.users_only_on_industrial:
+            # We only want to restrict industrial visits to listed users
+            return and_(
+                Proposal.proposalCode.not_in(["ic", "il", "in", "sw"]),
+                or_(
+                    BLSession.beamLineName.in_(allowed_beamlines),
+                    user_is_admin,
+                ),
+            )
+
+        return BLSession.beamLineName.in_(allowed_beamlines)
 
 def check_session(query: Select, user: GenericUser):
-    if is_admin(user.permissions):
+    """Include filters in provided query to ensure that only sessions the user has permission to view
+    are returned.
+
+    Args:
+        query: Original query
+        user: User to check against
+
+    Returns
+        Modified query"""
+    if not Config.facility.users_only_on_industrial and is_admin(user.permissions):
         return query
 
-    allowed_beamlines = get_allowed_beamlines(user.permissions)
     or_expressions = [SessionHasPerson.personId == user.id]
 
-    if allowed_beamlines:
-        or_expressions.append(BLSession.beamLineName.in_(allowed_beamlines))
+    staff_perms = _get_staff_perms(user)
+    if staff_perms is not None:
+        or_expressions.append(staff_perms)
 
     return (
         query.distinct()
         .join(
             SessionHasPerson,
             SessionHasPerson.sessionId == BLSession.sessionId,
-            isouter=(len(allowed_beamlines) > 0),
+            isouter=(staff_perms is not None),
         )
         .filter(
             or_(*or_expressions),
@@ -40,21 +72,30 @@ def check_session(query: Select, user: GenericUser):
 
 
 def check_proposal(query: Select, user: GenericUser):
-    if is_admin(user.permissions):
+    """Include filters in provided query to ensure that only proposals the user has permission to view
+    are returned.
+
+    Args:
+        query: Original query
+        user: User to check against
+
+    Returns
+        Modified query"""
+    if not Config.facility.users_only_on_industrial and is_admin(user.permissions):
         return query
 
-    allowed_beamlines = get_allowed_beamlines(user.permissions)
     or_expressions = [ProposalHasPerson.personId == user.id]
 
-    if allowed_beamlines:
-        or_expressions.append(BLSession.beamLineName.in_(allowed_beamlines))
+    staff_perms = _get_staff_perms(user)
+    if staff_perms is not None:
+        or_expressions.append(staff_perms)
 
     return (
         query.distinct()
         .join(
             ProposalHasPerson,
             ProposalHasPerson.proposalId == Proposal.proposalId,
-            isouter=(len(allowed_beamlines) > 0),
+            isouter=(staff_perms is not None),
         )
         .filter(
             or_(*or_expressions),

--- a/src/pato/utils/auth.py
+++ b/src/pato/utils/auth.py
@@ -39,13 +39,14 @@ def _get_staff_perms(user: GenericUser):
 
         return BLSession.beamLineName.in_(allowed_beamlines)
 
-def check_session(query: Select, user: GenericUser):
+def check_session(query: Select, user: GenericUser, join_proposal: bool = False):
     """Include filters in provided query to ensure that only sessions the user has permission to view
     are returned.
 
     Args:
         query: Original query
         user: User to check against
+        join_proposal: Join proposal when building query
 
     Returns
         Modified query"""
@@ -56,6 +57,8 @@ def check_session(query: Select, user: GenericUser):
 
     staff_perms = _get_staff_perms(user)
     if staff_perms is not None:
+        if Config.facility.users_only_on_industrial and join_proposal:
+            query = query.join(Proposal, BLSession.proposalId == Proposal.proposalId)
         or_expressions.append(staff_perms)
 
     return (

--- a/src/pato/utils/config.py
+++ b/src/pato/utils/config.py
@@ -23,6 +23,7 @@ class Facility:
     active_session_cutoff: int = 5
     sample_handling_url: str = "https://ebic-sample-handling.diamond.ac.uk"
     frontend_url: str = "http://localhost/"
+    users_only_on_industrial: bool = False
 
 
 @dataclass

--- a/src/pato/utils/database.py
+++ b/src/pato/utils/database.py
@@ -1,11 +1,8 @@
 import os
-from typing import Optional
 
-from fastapi import HTTPException, status
 from lims_utils.database import Database
-from lims_utils.models import Paged
 from lims_utils.tables import Base
-from sqlalchemy import Select, create_engine, func, literal_column, select
+from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from .config import Config
@@ -21,43 +18,6 @@ engine = create_engine(
 )
 
 session_factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-
-def fast_count(query: Select) -> int:
-    return db.session.execute(
-        query.with_only_columns(func.count(literal_column("1"))).order_by(None)
-    ).scalar_one()
-
-
-def paginate(
-    query: Select,
-    items: int,
-    page: int,
-    slow_count=True,
-    precounted_total: Optional[int] = None,
-):
-    if precounted_total is not None:
-        total = precounted_total
-    elif slow_count:
-        total = db.session.execute(
-            select(func.count(literal_column("1"))).select_from(query.subquery())
-        ).scalar_one()
-    else:
-        total = fast_count(query)
-
-    if not total:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="No items found",
-        )
-
-    if page < 0:
-        page = (total // items) + page
-
-    data = db.session.execute(query.limit(items).offset((page) * items)).all()
-
-    return Paged(items=data, total=total, limit=items, page=page)
-
 
 def unravel(model: Base):
     return list(model.__table__.columns)

--- a/src/pato/utils/generic.py
+++ b/src/pato/utils/generic.py
@@ -67,14 +67,6 @@ def validate_path(func):
     return wrap
 
 
-def filter_model(original: BaseModel, filter: list[str]):
-    for key in original.model_fields.keys():
-        if key in filter:
-            setattr(original, key, None)
-
-    return original
-
-
 def time_ago(delta: datetime.timedelta):
     today = datetime.date.today()
     return today - delta

--- a/tests/movies/test_ids.py
+++ b/tests/movies/test_ids.py
@@ -5,3 +5,7 @@ def test_get_movie_info(mock_permissions, client):
     assert resp.json()["foilHoleId"] == 1
     assert resp.json()["gridSquareId"] == 1
 
+def test_inexistent(mock_permissions, client):
+    """Should raise exception if movie not in database"""
+    resp = client.get("/movies/9999")
+    assert resp.status_code == 404

--- a/tests/proposals/test_proposal.py
+++ b/tests/proposals/test_proposal.py
@@ -1,15 +1,18 @@
 import pytest
 
-from ..users import admin, em_admin, mx_admin, user
+from pato.utils.config import Config
+
+from ..users import admin, em_admin, industrial_user, mx_admin, user
 
 
 @pytest.mark.parametrize(
     ["mock_user", "expected_count"],
     [
         pytest.param(mx_admin, 2, id="mx"),
+        pytest.param(industrial_user, 1, id="industrial_user"),
         pytest.param(user, 1, id="user"),
-        pytest.param(em_admin, 1, id="em"),
-        pytest.param(admin, 5, id="admin"),
+        pytest.param(em_admin, 2, id="em"),
+        pytest.param(admin, 6, id="admin"),
     ],
     indirect=["mock_user"],
 )
@@ -50,3 +53,24 @@ def test_search_title(mock_user, client):
     resp = client.get("/proposals?search=Test%20Proposal")
     assert resp.status_code == 200
     assert resp.json()["total"] == 2
+
+
+@pytest.mark.parametrize(
+    ["mock_user", "expected_count"],
+    [
+        pytest.param(mx_admin, 2, id="mx"),
+        pytest.param(industrial_user, 1, id="industrial_user"),
+        pytest.param(user, 1, id="user"),
+        pytest.param(em_admin, 1, id="em"),
+        pytest.param(admin, 5, id="admin"),
+    ],
+    indirect=["mock_user"],
+)
+def test_industrial_users_only(mock_user, expected_count, client):
+    """Only return non-industrial proposals to staff if users_only_on_industrial is set"""
+    Config.facility.users_only_on_industrial = True
+    resp = client.get("/proposals")
+    Config.facility.users_only_on_industrial = False
+
+    assert resp.status_code == 200
+    assert resp.json()["total"] == expected_count

--- a/tests/proposals/test_proposal.py
+++ b/tests/proposals/test_proposal.py
@@ -62,12 +62,12 @@ def test_search_title(mock_user, client):
         pytest.param(industrial_user, 1, id="industrial_user"),
         pytest.param(user, 1, id="user"),
         pytest.param(em_admin, 1, id="em"),
-        pytest.param(admin, 5, id="admin"),
+        pytest.param(admin, 6, id="admin"),
     ],
     indirect=["mock_user"],
 )
 def test_industrial_users_only(mock_user, expected_count, client):
-    """Only return non-industrial proposals to staff if users_only_on_industrial is set"""
+    """Only return non-industrial proposals to non-admin staff if users_only_on_industrial is set"""
     Config.facility.users_only_on_industrial = True
     resp = client.get("/proposals")
     Config.facility.users_only_on_industrial = False

--- a/tests/sessions/test_sessions.py
+++ b/tests/sessions/test_sessions.py
@@ -102,12 +102,12 @@ def test_date_start(mock_user, client):
         pytest.param(user, 0, id="user"),
         pytest.param(em_admin, 0, id="em"),
         pytest.param(industrial_user, 1, id="industrial-user"),
-        pytest.param(admin, 0, id="admin"),
+        pytest.param(admin, 1, id="admin"),
     ],
     indirect=["mock_user"],
 )
 def test_industrial_users_only(mock_user, expected_count, client):
-    """Only return non-industrial sessions to staff if users_only_on_industrial is set """
+    """Only return non-industrial sessions to non-admin staff if users_only_on_industrial is set """
     Config.facility.users_only_on_industrial = True
     resp = client.get(
         "/sessions?proposal=in1"

--- a/tests/sessions/test_sessions.py
+++ b/tests/sessions/test_sessions.py
@@ -1,14 +1,17 @@
 import pytest
 
-from ..users import admin, em_admin, user
+from pato.utils.config import Config
+
+from ..users import admin, em_admin, industrial_user, user
 
 
 @pytest.mark.parametrize(
     ["mock_user", "expected_count"],
     [
         pytest.param(user, 1, id="user"),
-        pytest.param(em_admin, 2, id="em"),
-        pytest.param(admin, 2, id="admin"),
+        pytest.param(industrial_user, 1, id="industrial-user"),
+        pytest.param(em_admin, 3, id="em"),
+        pytest.param(admin, 3, id="admin"),
     ],
     indirect=["mock_user"],
 )
@@ -34,7 +37,7 @@ def test_get_collection_groups(mock_user, client):
     sessions = resp.json()
 
     assert resp.status_code == 200
-    assert sessions["total"] == 2
+    assert sessions["total"] == 3
     assert sessions["items"][0]["collectionGroups"] == 1
 
 
@@ -42,7 +45,10 @@ def test_get_collection_groups(mock_user, client):
 def test_get_inexistent_proposal(mock_user, client):
     """Try to get visits for proposal that does not exist"""
     resp = client.get("/sessions?proposal=xx12345")
-    assert resp.status_code == 404
+    sessions = resp.json()
+
+    assert resp.status_code == 200
+    assert sessions["total"] == 0
 
 
 @pytest.mark.parametrize("mock_user", [em_admin], indirect=True)
@@ -65,14 +71,17 @@ def test_get_user(mock_user, client):
 def test_get_forbidden(mock_user, client):
     """Try to get visits for proposal that does not belong to an user"""
     resp = client.get("/sessions?proposal=cm14451")
-    assert resp.status_code == 404
+    sessions = resp.json()
+
+    assert resp.status_code == 200
+    assert sessions["total"] == 0
 
 
 @pytest.mark.parametrize("mock_user", [admin], indirect=True)
 def test_date_end(mock_user, client):
     """Try to get visits between two dates"""
     resp = client.get(
-        "/sessions?minEndDate=2022-10-21 09:00:00.000&maxEndDate=2024-10-21 09:00:00.000"  # noqa: E501
+        "/sessions?minEndDate=2022-10-21 09:00:00.000&maxEndDate=2024-10-21 09:00:00.000"
     )
     assert resp.status_code == 200
     assert resp.json()["total"] == 2
@@ -82,7 +91,28 @@ def test_date_end(mock_user, client):
 def test_date_start(mock_user, client):
     """Try to get visits between two dates"""
     resp = client.get(
-        "/sessions?minStartDate=2022-10-21 09:00:00.000&maxStartDate=2024-10-21 09:00:00.000"  # noqa: E501
+        "/sessions?minStartDate=2022-10-21 09:00:00.000&maxStartDate=2024-10-21 09:00:00.000"
     )
     assert resp.status_code == 200
     assert resp.json()["total"] == 2
+
+@pytest.mark.parametrize(
+    ["mock_user", "expected_count"],
+    [
+        pytest.param(user, 0, id="user"),
+        pytest.param(em_admin, 0, id="em"),
+        pytest.param(industrial_user, 1, id="industrial-user"),
+        pytest.param(admin, 0, id="admin"),
+    ],
+    indirect=["mock_user"],
+)
+def test_industrial_users_only(mock_user, expected_count, client):
+    """Only return non-industrial sessions to staff if users_only_on_industrial is set """
+    Config.facility.users_only_on_industrial = True
+    resp = client.get(
+        "/sessions?proposal=in1"
+    )
+    Config.facility.users_only_on_industrial = False
+
+    assert resp.status_code == 200
+    assert resp.json()["total"] == expected_count

--- a/tests/tomograms/test_motion.py
+++ b/tests/tomograms/test_motion.py
@@ -18,7 +18,10 @@ def test_get_middle(mock_permissions, client):
 def test_no_tilt_alignment(mock_permissions, client):
     """Get motion correction without tilt alignment data"""
     resp = client.get("/tomograms/3/motion")
-    assert resp.status_code == 404
+    sessions = resp.json()
+
+    assert resp.status_code == 200
+    assert sessions["total"] == 0
 
 
 def test_nth_motion(mock_permissions, client):

--- a/tests/users.py
+++ b/tests/users.py
@@ -30,6 +30,16 @@ user = GenericUser(
     email="user@diamond.ac.uk",
 )
 
+industrial_user = GenericUser(
+    fedid="industrial",
+    id=46435,
+    familyName="Industrial",
+    title="Dr.",
+    givenName="User",
+    permissions=[],
+    email="industrial-user@diamond.ac.uk",
+)
+
 mx_admin = GenericUser(
     fedid="mx_admin",
     id=16000,


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1698](https://jira.diamond.ac.uk/browse/LIMS-1698)

Note: I've merged `feature/lims-1707/heatmap` into this branch by accident, it will include changes from both branches

**Summary**:

To prevent unwanted data access, this pull request adds the option to limit access to visits/proposals to those who are directly listed as part of that visit/proposal, and no one else (including staff).

**Changes**:

- Add option to restrict proposal/visit visibility to members of that proposal/visit (`users_only_on_industrial`)
- Return empty array for tomograms with no motion data/proposals with no sessions

**To test**:

- Send a GET request to resources which belong to industrial proposals (such as movies, bFactorFit, CTF, etc.) (`/autoProc/99498883/ctf`) and ensure 404 is returned
- Send a GET request to `/proposals?search=in`, check if no industry proposals are returned (prefixed by `ic`, `il`, `sw` or `in`)
- Send a GET request to `/sessions?proposal=in1`, check if no sessions are returned
- Add yourself to that proposal and visit, repeat, check if 200 is returned
