### PR TITLE
[LIMS-1749] Return angular efficiency and suggested tilt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,10 @@ dependencies = [
     "requests~=2.32.3",
     "mysqlclient~=2.2.7",
     "mysql-connector-python~=8.2.0",
-    "pydantic[email]~=2.11.3",
+    "pydantic[email]~=2.11.5",
     "fpdf2~=2.8.3",
     "types-requests",
-    "lims-utils~=0.4.4"
+    "lims-utils~=0.4.6"
 ]
 dynamic = ["version"]
 license.file = "LICENSE"

--- a/src/pato/models/response.py
+++ b/src/pato/models/response.py
@@ -442,6 +442,8 @@ class Classification(OrmBaseModel):
     selected: Optional[bool] = None
     bFactorFitIntercept: Optional[float] = None
     bFactorFitLinear: Optional[float] = None
+    angularEfficiency: Optional[float] = None
+    suggestedTilt: Optional[float] = None
 
 
 class RelativeIceThickness(OrmBaseModel):


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1749](https://jira.diamond.ac.uk/browse/LIMS-1749)

**Summary**:

Angular efficiency and suggested tilt are now returned in classification endpoints

**Changes**:

- List changes made in this pull request

**To test**:

- Make a GET request to https://local-oidc-test.diamond.ac.uk:9000/api/autoProc/104976840/classification?limit=8&page=0&sortBy=particles&classType=3d&excludeUnselected=false, ensure `angularEfficiency` and `suggestedTilt` are included in the returned objects
