### PR TITLE
[LIMS-1774] Fix slow query, require session/proposal when fetching DCGs

### DIFF
--- a/database/data.sql
+++ b/database/data.sql
@@ -68,7 +68,7 @@ CREATE TABLE `AdminVar` (
 LOCK TABLES `AdminVar` WRITE;
 /*!40000 ALTER TABLE `AdminVar` DISABLE KEYS */;
 INSERT INTO `AdminVar` VALUES
-(4,'schemaVersion','1.33.0');
+(4,'schemaVersion','4.7.0');
 /*!40000 ALTER TABLE `AdminVar` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -310,7 +310,7 @@ CREATE TABLE `AutoProcProgramAttachment` (
   PRIMARY KEY (`autoProcProgramAttachmentId`),
   KEY `AutoProcProgramAttachmentIdx1` (`autoProcProgramId`),
   CONSTRAINT `AutoProcProgramAttachmentFk1` FOREIGN KEY (`autoProcProgramId`) REFERENCES `AutoProcProgram` (`autoProcProgramId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=1037296 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=1037372 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -928,7 +928,7 @@ CREATE TABLE `BLSample` (
   CONSTRAINT `BLSample_ibfk_1` FOREIGN KEY (`containerId`) REFERENCES `Container` (`containerId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `BLSample_ibfk_2` FOREIGN KEY (`crystalId`) REFERENCES `Crystal` (`crystalId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `BLSample_ibfk_3` FOREIGN KEY (`diffractionPlanId`) REFERENCES `DiffractionPlan` (`diffractionPlanId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=400312 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=402938 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -977,10 +977,13 @@ CREATE TABLE `BLSampleGroup` (
   `blSampleGroupId` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(100) DEFAULT NULL COMMENT 'Human-readable name',
   `proposalId` int(10) unsigned DEFAULT NULL,
+  `ownerId` int(10) unsigned DEFAULT NULL COMMENT 'Sample group owner',
   PRIMARY KEY (`blSampleGroupId`),
   KEY `BLSampleGroup_fk_proposalId` (`proposalId`),
+  KEY `BLSampleGroup_fk_ownerId` (`ownerId`),
+  CONSTRAINT `BLSampleGroup_fk_ownerId` FOREIGN KEY (`ownerId`) REFERENCES `Person` (`personId`) ON UPDATE CASCADE,
   CONSTRAINT `BLSampleGroup_fk_proposalId` FOREIGN KEY (`proposalId`) REFERENCES `Proposal` (`proposalId`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=98 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -990,9 +993,10 @@ CREATE TABLE `BLSampleGroup` (
 LOCK TABLES `BLSampleGroup` WRITE;
 /*!40000 ALTER TABLE `BLSampleGroup` DISABLE KEYS */;
 INSERT INTO `BLSampleGroup` VALUES
-(5,NULL,37027),
-(6,'foo',37027),
-(7,'bar',37027);
+(5,NULL,37027,NULL),
+(6,'foo',37027,NULL),
+(7,'bar',37027,NULL),
+(10,'existingname',141666,NULL);
 /*!40000 ALTER TABLE `BLSampleGroup` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -1300,6 +1304,40 @@ LOCK TABLES `BLSampleImage_has_Positioner` WRITE;
 UNLOCK TABLES;
 
 --
+-- Table structure for table `BLSamplePosition`
+--
+
+DROP TABLE IF EXISTS `BLSamplePosition`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `BLSamplePosition` (
+  `blSamplePositionId` int(11) unsigned NOT NULL AUTO_INCREMENT COMMENT 'Primary key (auto-incremented)',
+  `blSampleId` int(11) unsigned NOT NULL COMMENT 'FK, references parent sample',
+  `posX` double DEFAULT NULL,
+  `posY` double DEFAULT NULL,
+  `posZ` double DEFAULT NULL,
+  `recordTimeStamp` datetime DEFAULT current_timestamp(),
+  `positionType` enum('dispensing') DEFAULT NULL COMMENT 'Type of marked position (e.g.: dispensing location)',
+  PRIMARY KEY (`blSamplePositionId`),
+  KEY `BLSamplePosition_fk_blSampleId` (`blSampleId`),
+  CONSTRAINT `BLSamplePosition_fk_blSampleId` FOREIGN KEY (`blSampleId`) REFERENCES `BLSample` (`blSampleId`)
+) ENGINE=InnoDB AUTO_INCREMENT=69 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `BLSamplePosition`
+--
+
+LOCK TABLES `BLSamplePosition` WRITE;
+/*!40000 ALTER TABLE `BLSamplePosition` DISABLE KEYS */;
+INSERT INTO `BLSamplePosition` VALUES
+(3,398833,1,1,1,'2025-05-14 08:22:40',NULL),
+(4,398833,1,1,1,'2025-05-14 08:22:40','dispensing'),
+(14,398832,1,1,1,'2025-05-14 08:22:40',NULL);
+/*!40000 ALTER TABLE `BLSamplePosition` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
 -- Table structure for table `BLSampleType`
 --
 
@@ -1482,7 +1520,7 @@ CREATE TABLE `BLSession` (
   CONSTRAINT `BLSession_fk_beamCalendarId` FOREIGN KEY (`beamCalendarId`) REFERENCES `BeamCalendar` (`beamCalendarId`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `BLSession_ibfk_1` FOREIGN KEY (`proposalId`) REFERENCES `Proposal` (`proposalId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `BLSession_ibfk_2` FOREIGN KEY (`beamLineSetupId`) REFERENCES `BeamLineSetup` (`beamLineSetupId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=27464203 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=27464428 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1864,7 +1902,7 @@ CREATE TABLE `CTF` (
   KEY `CTF_ibfk2` (`autoProcProgramId`),
   CONSTRAINT `CTF_ibfk1` FOREIGN KEY (`motionCorrectionId`) REFERENCES `MotionCorrection` (`motionCorrectionId`),
   CONSTRAINT `CTF_ibfk2` FOREIGN KEY (`autoProcProgramId`) REFERENCES `AutoProcProgram` (`autoProcProgramId`)
-) ENGINE=InnoDB AUTO_INCREMENT=29 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=27 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2183,7 +2221,7 @@ CREATE TABLE `Container` (
   CONSTRAINT `Container_ibfk8` FOREIGN KEY (`containerRegistryId`) REFERENCES `ContainerRegistry` (`containerRegistryId`),
   CONSTRAINT `Container_ibfk9` FOREIGN KEY (`priorityPipelineId`) REFERENCES `ProcessingPipeline` (`processingPipelineId`),
   CONSTRAINT `Container_ibfk_1` FOREIGN KEY (`dewarId`) REFERENCES `Dewar` (`dewarId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=36230 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=38518 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2631,7 +2669,7 @@ CREATE TABLE `Crystal` (
   KEY `Crystal_FKIndex2` (`diffractionPlanId`),
   CONSTRAINT `Crystal_ibfk_1` FOREIGN KEY (`proteinId`) REFERENCES `Protein` (`proteinId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `Crystal_ibfk_2` FOREIGN KEY (`diffractionPlanId`) REFERENCES `DiffractionPlan` (`diffractionPlanId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=334377 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=336673 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2884,7 +2922,7 @@ CREATE TABLE `DataCollection` (
   CONSTRAINT `DataCollection_ibfk_6` FOREIGN KEY (`startPositionId`) REFERENCES `MotorPosition` (`motorPositionId`),
   CONSTRAINT `DataCollection_ibfk_7` FOREIGN KEY (`endPositionId`) REFERENCES `MotorPosition` (`motorPositionId`),
   CONSTRAINT `DataCollection_ibfk_8` FOREIGN KEY (`blSubSampleId`) REFERENCES `BLSubSample` (`blSubSampleId`)
-) ENGINE=InnoDB AUTO_INCREMENT=6017880 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=6018014 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3001,7 +3039,7 @@ CREATE TABLE `DataCollectionGroup` (
   CONSTRAINT `DataCollectionGroup_ibfk_1` FOREIGN KEY (`blSampleId`) REFERENCES `BLSample` (`blSampleId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `DataCollectionGroup_ibfk_2` FOREIGN KEY (`sessionId`) REFERENCES `BLSession` (`sessionId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `DataCollectionGroup_ibfk_4` FOREIGN KEY (`experimentTypeId`) REFERENCES `ExperimentType` (`experimentTypeId`)
-) ENGINE=InnoDB AUTO_INCREMENT=5441137 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci COMMENT='a dataCollectionGroup is a group of dataCollection for a spe';
+) ENGINE=InnoDB AUTO_INCREMENT=5441267 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci COMMENT='a dataCollectionGroup is a group of dataCollection for a spe';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3149,7 +3187,7 @@ CREATE TABLE `Dewar` (
   CONSTRAINT `Dewar_fk_dewarRegistryId` FOREIGN KEY (`dewarRegistryId`) REFERENCES `DewarRegistry` (`dewarRegistryId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `Dewar_fk_firstExperimentId` FOREIGN KEY (`firstExperimentId`) REFERENCES `BLSession` (`sessionId`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `Dewar_ibfk_1` FOREIGN KEY (`shippingId`) REFERENCES `Shipping` (`shippingId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=9857 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=12074 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3244,7 +3282,7 @@ CREATE TABLE `DewarRegistry` (
   KEY `DewarRegistry_ibfk_2` (`labContactId`),
   CONSTRAINT `DewarRegistry_ibfk_1` FOREIGN KEY (`proposalId`) REFERENCES `Proposal` (`proposalId`) ON DELETE NO ACTION ON UPDATE CASCADE,
   CONSTRAINT `DewarRegistry_ibfk_2` FOREIGN KEY (`labContactId`) REFERENCES `LabContact` (`labContactId`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=281 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=503 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3282,8 +3320,8 @@ CREATE TABLE `DewarRegistry_has_Proposal` (
   CONSTRAINT `DewarRegistry_has_Proposal_ibfk1` FOREIGN KEY (`dewarRegistryId`) REFERENCES `DewarRegistry` (`dewarRegistryId`),
   CONSTRAINT `DewarRegistry_has_Proposal_ibfk2` FOREIGN KEY (`proposalId`) REFERENCES `Proposal` (`proposalId`),
   CONSTRAINT `DewarRegistry_has_Proposal_ibfk3` FOREIGN KEY (`personId`) REFERENCES `Person` (`personId`),
-  CONSTRAINT `DewarRegistry_has_Proposal_ibfk4` FOREIGN KEY (`labContactId`) REFERENCES `LabContact` (`labContactId`) ON DELETE NO ACTION ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=181 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+  CONSTRAINT `DewarRegistry_has_Proposal_ibfk4` FOREIGN KEY (`labContactId`) REFERENCES `LabContact` (`labContactId`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB AUTO_INCREMENT=329 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3337,12 +3375,12 @@ CREATE TABLE `DewarTransportHistory` (
   `DewarTransportHistoryId` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `dewarId` int(10) unsigned DEFAULT NULL,
   `dewarStatus` varchar(45) NOT NULL,
-  `storageLocation` varchar(45) NOT NULL,
-  `arrivalDate` datetime NOT NULL,
+  `storageLocation` varchar(45) DEFAULT NULL,
+  `arrivalDate` datetime DEFAULT NULL,
   PRIMARY KEY (`DewarTransportHistoryId`),
   KEY `DewarTransportHistory_FKIndex1` (`dewarId`),
   CONSTRAINT `DewarTransportHistory_ibfk_1` FOREIGN KEY (`dewarId`) REFERENCES `Dewar` (`dewarId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=54 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3351,6 +3389,9 @@ CREATE TABLE `DewarTransportHistory` (
 
 LOCK TABLES `DewarTransportHistory` WRITE;
 /*!40000 ALTER TABLE `DewarTransportHistory` DISABLE KEYS */;
+INSERT INTO `DewarTransportHistory` VALUES
+(1,576,'at-facility','','2025-01-01 00:00:00'),
+(2,576,'opened','','2025-01-01 02:00:00');
 /*!40000 ALTER TABLE `DewarTransportHistory` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -3434,7 +3475,7 @@ CREATE TABLE `DiffractionPlan` (
   CONSTRAINT `DiffractionPlan_ibfk1` FOREIGN KEY (`presetForProposalId`) REFERENCES `Proposal` (`proposalId`),
   CONSTRAINT `DiffractionPlan_ibfk2` FOREIGN KEY (`purificationColumnId`) REFERENCES `PurificationColumn` (`purificationColumnId`),
   CONSTRAINT `DiffractionPlan_ibfk3` FOREIGN KEY (`experimentTypeId`) REFERENCES `ExperimentType` (`experimentTypeId`)
-) ENGINE=InnoDB AUTO_INCREMENT=199441 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=202363 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -3847,7 +3888,7 @@ CREATE TABLE `GridInfo` (
   KEY `GridInfo_fk_dataCollectionId` (`dataCollectionId`),
   CONSTRAINT `GridInfo_fk_dataCollectionId` FOREIGN KEY (`dataCollectionId`) REFERENCES `DataCollection` (`dataCollectionId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `GridInfo_ibfk_2` FOREIGN KEY (`dataCollectionGroupId`) REFERENCES `DataCollectionGroup` (`dataCollectionGroupId`)
-) ENGINE=InnoDB AUTO_INCREMENT=1281481 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=1281633 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -4383,7 +4424,7 @@ CREATE TABLE `MotionCorrection` (
   CONSTRAINT `MotionCorrection_ibfk2` FOREIGN KEY (`autoProcProgramId`) REFERENCES `AutoProcProgram` (`autoProcProgramId`),
   CONSTRAINT `MotionCorrection_ibfk3` FOREIGN KEY (`movieId`) REFERENCES `Movie` (`movieId`),
   CONSTRAINT `_MotionCorrection_ibfk1` FOREIGN KEY (`dataCollectionId`) REFERENCES `DataCollection` (`dataCollectionId`)
-) ENGINE=InnoDB AUTO_INCREMENT=31 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=30 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -4798,7 +4839,7 @@ CREATE TABLE `ParticlePicker` (
   KEY `ParticlePicker_fk_motionCorrectionId` (`firstMotionCorrectionId`),
   CONSTRAINT `ParticlePicker_fk_motionCorrectionId` FOREIGN KEY (`firstMotionCorrectionId`) REFERENCES `MotionCorrection` (`motionCorrectionId`) ON DELETE NO ACTION ON UPDATE CASCADE,
   CONSTRAINT `ParticlePicker_fk_programId` FOREIGN KEY (`programId`) REFERENCES `AutoProcProgram` (`autoProcProgramId`) ON DELETE NO ACTION ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci COMMENT='An instance of a particle picker program that was run';
+) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci COMMENT='An instance of a particle picker program that was run';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -4902,7 +4943,7 @@ CREATE TABLE `Person` (
   KEY `Person_FKIndexFamilyName` (`familyName`),
   KEY `siteId` (`siteId`),
   CONSTRAINT `Person_ibfk_1` FOREIGN KEY (`laboratoryId`) REFERENCES `Laboratory` (`laboratoryId`) ON DELETE NO ACTION ON UPDATE NO ACTION
-) ENGINE=InnoDB AUTO_INCREMENT=46457 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=46607 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -5177,7 +5218,7 @@ CREATE TABLE `Position` (
   PRIMARY KEY (`positionId`),
   KEY `Position_FKIndex1` (`relativePositionId`),
   CONSTRAINT `Position_relativePositionfk_1` FOREIGN KEY (`relativePositionId`) REFERENCES `Position` (`positionId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=244 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=396 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -5299,7 +5340,7 @@ CREATE TABLE `ProcessingJob` (
   PRIMARY KEY (`processingJobId`),
   KEY `ProcessingJob_ibfk1` (`dataCollectionId`),
   CONSTRAINT `ProcessingJob_ibfk1` FOREIGN KEY (`dataCollectionId`) REFERENCES `DataCollection` (`dataCollectionId`)
-) ENGINE=InnoDB AUTO_INCREMENT=4134 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci COMMENT='From this we get both job times and lag times';
+) ENGINE=InnoDB AUTO_INCREMENT=3972 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci COMMENT='From this we get both job times and lag times';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -5394,7 +5435,7 @@ CREATE TABLE `ProcessingJobParameter` (
   KEY `ProcessingJobParameter_ibfk1` (`processingJobId`),
   KEY `ProcessingJobParameter_idx_paramKey_procJobId` (`parameterKey`,`processingJobId`),
   CONSTRAINT `ProcessingJobParameter_ibfk1` FOREIGN KEY (`processingJobId`) REFERENCES `ProcessingJob` (`processingJobId`)
-) ENGINE=InnoDB AUTO_INCREMENT=28955 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=27155 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -5762,7 +5803,7 @@ CREATE TABLE `Proposal` (
   UNIQUE KEY `Proposal_FKIndexCodeNumber` (`proposalCode`,`proposalNumber`),
   KEY `Proposal_FKIndex1` (`personId`),
   CONSTRAINT `Proposal_ibfk_1` FOREIGN KEY (`personId`) REFERENCES `Person` (`personId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=1000358 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=1000586 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -5855,7 +5896,7 @@ CREATE TABLE `Protein` (
   CONSTRAINT `Protein_ibfk_1` FOREIGN KEY (`proposalId`) REFERENCES `Proposal` (`proposalId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `protein_fk3` FOREIGN KEY (`componentTypeId`) REFERENCES `ComponentType` (`componentTypeId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `protein_fk4` FOREIGN KEY (`concentrationTypeId`) REFERENCES `ConcentrationType` (`concentrationTypeId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=123712 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=123860 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -6010,7 +6051,7 @@ CREATE TABLE `RobotAction` (
   KEY `RobotAction_FK2` (`blsampleId`),
   CONSTRAINT `RobotAction_FK1` FOREIGN KEY (`blsessionId`) REFERENCES `BLSession` (`sessionId`),
   CONSTRAINT `RobotAction_FK2` FOREIGN KEY (`blsampleId`) REFERENCES `BLSample` (`blSampleId`)
-) ENGINE=InnoDB AUTO_INCREMENT=412 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci COMMENT='Robot actions as reported by GDA';
+) ENGINE=InnoDB AUTO_INCREMENT=560 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci COMMENT='Robot actions as reported by GDA';
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -6301,7 +6342,7 @@ CREATE TABLE `SchemaStatus` (
   `recordTimeStamp` timestamp NOT NULL DEFAULT current_timestamp(),
   PRIMARY KEY (`schemaStatusId`),
   UNIQUE KEY `scriptName` (`scriptName`)
-) ENGINE=InnoDB AUTO_INCREMENT=255 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=264 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -6519,7 +6560,16 @@ INSERT INTO `SchemaStatus` VALUES
 (248,'2024_08_08_ProcessedTomogram.sql','DONE','2024-09-06 08:58:07'),
 (250,'2024_12_04_AutoProcProgramAttachment_deleted.sql','DONE','2024-12-18 11:30:15'),
 (251,'2024_09_25_AutoProcProgram_processingPipelineId.sql','DONE','2024-12-18 11:48:43'),
-(253,'2025_03_05_Dewar_dewarRegistryId.sql','DONE','2025-04-28 11:05:07');
+(253,'2025_03_05_Dewar_dewarRegistryId.sql','DONE','2025-04-28 11:05:07'),
+(255,'2025_04_11_Position_blSampleId_positionType.sql','DONE','2025-05-14 08:13:36'),
+(256,'2025_03_20_ParticleClassification_angularEfficiency_suggestedTilt.sql','ONGOING','2025-05-14 08:13:46'),
+(257,'2025_04_16_labContacts_fk_on_delete_set_null.sql','DONE','2025-05-14 08:13:55'),
+(258,'2025_04_29_DewarRegistry_fk_labContactId_on_delete_set_null.sql','DONE','2025-05-14 08:14:00'),
+(259,'2025_04_30_Shipping_fk_personId_on_delete_set_null.sql','DONE','2025-05-14 08:14:05'),
+(260,'2025_05_01_BLSamplePosition.sql','DONE','2025-05-14 08:14:11'),
+(261,'2025_05_01_XrayCentringResult_fk_blSampleId.sql','DONE','2025-05-14 08:14:16'),
+(262,'2025_05_02_BLSamplePosition_rename_column.sql','DONE','2025-05-14 08:14:21'),
+(263,'2025_05_12_AdminVar_bump_version.sql','DONE','2025-05-14 08:14:27');
 /*!40000 ALTER TABLE `SchemaStatus` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -7099,7 +7149,7 @@ CREATE TABLE `SessionType` (
   PRIMARY KEY (`sessionTypeId`),
   KEY `SessionType_FKIndex1` (`sessionId`),
   CONSTRAINT `SessionType_ibfk_1` FOREIGN KEY (`sessionId`) REFERENCES `BLSession` (`sessionId`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=76 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=224 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -7199,10 +7249,10 @@ CREATE TABLE `Shipping` (
   KEY `Shipping_FKIndexStatus` (`shippingStatus`),
   KEY `Shipping_ibfk_4` (`deliveryAgent_flightCodePersonId`),
   CONSTRAINT `Shipping_ibfk_1` FOREIGN KEY (`proposalId`) REFERENCES `Proposal` (`proposalId`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `Shipping_ibfk_2` FOREIGN KEY (`sendingLabContactId`) REFERENCES `LabContact` (`labContactId`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `Shipping_ibfk_3` FOREIGN KEY (`returnLabContactId`) REFERENCES `LabContact` (`labContactId`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `Shipping_ibfk_4` FOREIGN KEY (`deliveryAgent_flightCodePersonId`) REFERENCES `Person` (`personId`)
-) ENGINE=InnoDB AUTO_INCREMENT=8529 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+  CONSTRAINT `Shipping_ibfk_2` FOREIGN KEY (`sendingLabContactId`) REFERENCES `LabContact` (`labContactId`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `Shipping_ibfk_3` FOREIGN KEY (`returnLabContactId`) REFERENCES `LabContact` (`labContactId`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `Shipping_ibfk_4` FOREIGN KEY (`deliveryAgent_flightCodePersonId`) REFERENCES `Person` (`personId`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB AUTO_INCREMENT=10675 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -7956,7 +8006,7 @@ CREATE TABLE `XFEFluorescenceSpectrum` (
   CONSTRAINT `XFE_ibfk_1` FOREIGN KEY (`sessionId`) REFERENCES `BLSession` (`sessionId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `XFE_ibfk_2` FOREIGN KEY (`blSampleId`) REFERENCES `BLSample` (`blSampleId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `XFE_ibfk_3` FOREIGN KEY (`blSubSampleId`) REFERENCES `BLSubSample` (`blSubSampleId`)
-) ENGINE=InnoDB AUTO_INCREMENT=2242 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2390 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -8143,8 +8193,11 @@ CREATE TABLE `XrayCentringResult` (
   `status` enum('success','failure','pending') NOT NULL DEFAULT 'pending',
   `x` float DEFAULT NULL COMMENT 'position in number of boxes in direction of the fast scan within GridInfo grid',
   `y` float DEFAULT NULL COMMENT 'position in number of boxes in direction of the slow scan within GridInfo grid',
+  `blSampleId` int(11) unsigned DEFAULT NULL COMMENT 'The BLSample attributed for this x-ray centring result, i.e. the actual sample even for multi-pins',
   PRIMARY KEY (`xrayCentringResultId`),
   KEY `XrayCenteringResult_ibfk_1` (`gridInfoId`),
+  KEY `XrayCentringResult_fk_blSampleId` (`blSampleId`),
+  CONSTRAINT `XrayCentringResult_fk_blSampleId` FOREIGN KEY (`blSampleId`) REFERENCES `BLSample` (`blSampleId`) ON DELETE SET NULL ON UPDATE CASCADE,
   CONSTRAINT `XrayCentringResult_ibfk_1` FOREIGN KEY (`gridInfoId`) REFERENCES `GridInfo` (`gridInfoId`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -8295,4 +8348,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2025-05-07  9:21:32
+-- Dump completed on 2025-06-11 16:32:41

--- a/src/pato/routes/groups.py
+++ b/src/pato/routes/groups.py
@@ -30,19 +30,6 @@ def get_collection_group(
         group_id=groupId
     )
 
-@router.get("", response_model=Paged[DataCollectionGroupSummaryResponse])
-def get_collection_groups(
-    session: Optional[int] = None,
-    proposal: Optional[str] = None,
-    page: dict[str, int] = Depends(pagination),
-    search: Optional[str] = None,
-    user=Depends(User),
-):
-    """List collection groups belonging to a session"""
-    return crud.get_collection_groups(
-        session=session, proposal=proposal, search=search, user=user, **page
-    )
-
 
 @router.get("/{groupId}/dataCollections", response_model=Paged[DataCollectionSummary])
 def get_collections(

--- a/src/pato/routes/proposals.py
+++ b/src/pato/routes/proposals.py
@@ -3,11 +3,13 @@ from fastapi.responses import RedirectResponse
 from lims_utils.models import Paged, pagination
 
 from ..auth import Permissions, User
+from ..crud import groups as groups_crud
 from ..crud import proposals as crud
 from ..crud import sessions as sessions_crud
 from ..models.collections import DataCollectionCreationParameters
 from ..models.response import (
     BaseDataCollectionOut,
+    DataCollectionGroupSummaryResponse,
     ProposalResponse,
     SessionAllowsReprocessing,
     SessionResponse,
@@ -18,6 +20,20 @@ router = APIRouter(
     tags=["Proposals"],
     prefix="/proposals",
 )
+
+@router.get(
+    "/{proposalReference}/sessions/{visitNumber}/dataGroups",
+    response_model=Paged[DataCollectionGroupSummaryResponse],
+)
+def get_data_collection_groups(
+    proposalReference=Depends(Permissions.session),
+    page: dict[str, int] = Depends(pagination),
+    search: str | None = None,
+):
+    """List collection groups belonging to a session"""
+    return groups_crud.get_collection_groups(
+        proposal_reference=proposalReference, search=search, **page
+    )
 
 
 @router.get("", response_model=Paged[ProposalResponse])

--- a/tests/data_collection_groups/test_groups.py
+++ b/tests/data_collection_groups/test_groups.py
@@ -1,53 +1,15 @@
-import pytest
-
-from ..users import admin, em_admin, user
-
-
-@pytest.mark.parametrize("mock_user", [admin], indirect=True)
-def test_get_admin(mock_user, client):
-    """Get all data collection groups in a visit (request for admin)"""
-    resp = client.get("/dataGroups?proposal=cm31111&session=5")
-    assert resp.status_code == 200
-    assert resp.json()["total"] == 1
-
-
-@pytest.mark.parametrize("mock_user", [em_admin], indirect=True)
-def test_get_em_admin(mock_user, client):
-    """Get all collection groups in visit belonging to EM (request for EM admin)"""
-    resp = client.get("/dataGroups?proposal=cm31111&session=5")
-    assert resp.status_code == 200
-    assert resp.json()["total"] == 1
-
-
-@pytest.mark.parametrize("mock_user", [em_admin], indirect=True)
-def test_get_non_em(mock_user, client):
-    """Try to get all collection groups belonging to a non-EM visit (request for EM
-    admin)"""
-    resp = client.get("/dataGroups?proposal=cm14451&session=1")
-    assert len(resp.json()["items"]) == 0
-
-
-@pytest.mark.parametrize("mock_user", [user], indirect=True)
-def test_get_user(mock_user, client):
-    """Get data collection groups in a visit belonging to a regular user"""
-    resp = client.get("/dataGroups?proposal=cm31111&session=6")
+def test_get(mock_permissions, client):
+    """Get all data collection groups in a visit"""
+    resp = client.get("/proposals/cm31111/sessions/6/dataGroups")
+    print(resp.json())
     assert resp.status_code == 200
     assert resp.json()["total"] == 4
 
 
-@pytest.mark.parametrize("mock_user", [user], indirect=True)
-def test_get_forbidden(mock_user, client):
-    """Try to get data collection groups for a visit that does not belong to user"""
-    resp = client.get("/dataGroups?proposal=cm31111&session=5")
-    assert len(resp.json()["items"]) == 0
-
-
-@pytest.mark.parametrize("mock_user", [admin], indirect=True)
-def test_get_collection_count(mock_user, client):
-    """Get count of collections that belong to a data collection group"""
-    resp = client.get("/dataGroups?proposal=cm31111&session=6")
-    resp_json = resp.json()
-
+def test_get_search(mock_permissions, client):
+    """Get all collection groups filtering by comments"""
+    resp = client.get("/proposals/cm31111/sessions/6/dataGroups?search=Processed")
     assert resp.status_code == 200
-    assert resp_json["items"][1]["collections"] == 1
-    assert resp_json["items"][2]["collections"] == 2
+    assert resp.json()["total"] == 1
+
+

--- a/tests/data_collection_groups/test_groups.py
+++ b/tests/data_collection_groups/test_groups.py
@@ -1,7 +1,6 @@
 def test_get(mock_permissions, client):
     """Get all data collection groups in a visit"""
     resp = client.get("/proposals/cm31111/sessions/6/dataGroups")
-    print(resp.json())
     assert resp.status_code == 200
     assert resp.json()["total"] == 4
 


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1774](https://jira.diamond.ac.uk/browse/LIMS-1774)

**Summary**:

To make the queries less messy and performance, we must require proposal/session to get data collection groups, as that greatly simplifies authorisation logic and eliminates the need for subqueries.

**Changes**:

- Move `/dataGroups` endpoint to `/proposals/{proposalReference}/sessions/{visitNumber}/dataGroups`

**To test**:

- Make a request to `https://local-oidc-test.diamond.ac.uk:9000/api/proposals/bi34172/sessions/20/dataGroups?page=0&limit=20&search=`, ensure five data collection groups are returned
