### PR TITLE
[LIMS-1875] Allow user to hide empty search maps

### DIFF
--- a/src/pato/routes/groups.py
+++ b/src/pato/routes/groups.py
@@ -47,10 +47,16 @@ def get_collections(
 def get_grid_squares(
     groupId: int = Depends(Permissions.data_collection_group),
     hideSquares: bool = False,
+    hideEmptySearchMaps: bool = False,
     page: dict[str, int] = Depends(pagination),
 ):
     """Get child grid squares"""
-    return crud.get_grid_squares(dcg_id=groupId, hide_uncollected=hideSquares, **page)
+    return crud.get_grid_squares(
+        dcg_id=groupId,
+        hide_uncollected=hideSquares,
+        hide_empty_search_maps=hideEmptySearchMaps,
+        **page,
+    )
 
 
 @router.get("/{groupId}/atlas", response_model=Atlas)

--- a/tests/data_collection_groups/test_grid_squares.py
+++ b/tests/data_collection_groups/test_grid_squares.py
@@ -12,7 +12,7 @@ def test_get_empty(mock_permissions, client):
     assert len(resp.json()["items"]) == 1
 
 
-def test_get_empty_square_maps(mock_permissions, client):
+def test_get_empty_search_maps(mock_permissions, client):
     """Only get populated search maps"""
     resp = client.get(
         "/dataGroups/5440742/grid-squares", params="hideEmptySearchMaps=true"

--- a/tests/data_collection_groups/test_grid_squares.py
+++ b/tests/data_collection_groups/test_grid_squares.py
@@ -4,8 +4,18 @@ def test_get(mock_permissions, client):
     assert resp.status_code == 200
     assert len(resp.json()["items"]) == 2
 
+
 def test_get_empty(mock_permissions, client):
-    """Get only collected grid squares"""
+    """Only get collected grid squares"""
     resp = client.get("/dataGroups/5440742/grid-squares", params="hideSquares=true")
+    assert resp.status_code == 200
+    assert len(resp.json()["items"]) == 1
+
+
+def test_get_empty_square_maps(mock_permissions, client):
+    """Only get populated search maps"""
+    resp = client.get(
+        "/dataGroups/5440742/grid-squares", params="hideEmptySearchMaps=true"
+    )
     assert resp.status_code == 200
     assert len(resp.json()["items"]) == 1


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1875](https://jira.diamond.ac.uk/browse/LIMS-1875)

**Summary**:

Since search maps may not always collect tomograms, there needs to be a way for users to filter empty search maps, much like they do with uncollected grid squares. This PR adds this feature

**Changes**:

- Allow user to hide empty search maps

**To test**:

Assuming you're using the local test DB:

- Send a request to `/dataGroups/5440742/grid-squares`, check if two search maps (grid squares) are returned
- Send a request to `/dataGroups/5440742/grid-squares?hideEmptySearchMaps=true`, check if only one search map is returned
