### PR TITLE
[LIMS-1761] Add initial model uploads

### DIFF
--- a/src/pato/routes/proposals.py
+++ b/src/pato/routes/proposals.py
@@ -20,6 +20,7 @@ router = APIRouter(
     prefix="/proposals",
 )
 
+
 @router.get(
     "/{proposalReference}/sessions/{visitNumber}/dataGroups",
     response_model=Paged[DataCollectionGroupSummaryResponse],
@@ -91,5 +92,15 @@ def upload_processing_model(
 ):
     """Upload custom processing model"""
     return sessions_crud.upload_processing_model(
+        file=file, proposal_reference=proposalReference
+    )
+
+
+@router.post("/{proposalReference}/sessions/{visitNumber}/initialModel")
+def upload_initial_model(
+    file: UploadFile, proposalReference=Depends(Permissions.session)
+):
+    """Upload custom initial model"""
+    return sessions_crud.upload_initial_model(
         file=file, proposal_reference=proposalReference
     )

--- a/tests/sessions/test_upload_initial_model.py
+++ b/tests/sessions/test_upload_initial_model.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+from unittest.mock import mock_open, patch
+
+from lims_utils.tables import BLSession
+
+VALID_FILE = b"\x00" * 208 + b"\x4d\x41\x50"
+
+
+def active_mock(_):
+    return BLSession(
+        startDate=datetime(year=2022, month=1, day=1),
+        sessionId=27464088,
+        beamLineName="m12",
+    )
+
+
+@patch("pato.crud.sessions._validate_session_active", new=active_mock)
+@patch("builtins.open", new_callable=mock_open())
+@patch("pato.crud.sessions.os.path.isdir", new=lambda _: True)
+def test_post(_, mock_permissions, client):
+    """Should write file successfully if file matches expected signature"""
+    resp = client.post(
+        "/proposals/cm31111/sessions/5/initialModel",
+        files={"file": ("mrc.mrc", VALID_FILE, "application/octet-stream")},
+    )
+
+    assert resp.status_code == 200
+
+
+@patch("pato.crud.sessions._validate_session_active", new=active_mock)
+@patch("builtins.open", new_callable=mock_open())
+def test_invalid_file_signature(_, mock_permissions, client):
+    """Should raise exception if file signature doesn't match MRC file signature"""
+    resp = client.post(
+        "/proposals/cm31111/sessions/5/initialModel",
+        files={"file": ("not-mrc.mrc", b"\x01\x02", "application/octet-stream")},
+    )
+
+    assert resp.status_code == 415
+
+
+@patch("pato.crud.sessions._validate_session_active", new=active_mock)
+@patch("builtins.open", side_effect=OSError("Write Error"))
+def test_write_error(_, mock_permissions, client):
+    """Should return 500 if there was an error writing the file"""
+    resp = client.post(
+        "/proposals/cm31111/sessions/5/initialModel",
+        files={"file": ("mrc.mrc", VALID_FILE, "application/octet-stream")},
+    )
+
+    assert resp.status_code == 500
+
+
+@patch("pato.crud.sessions._validate_session_active", new=active_mock)
+@patch("builtins.open", side_effect=OSError("Write Error"))
+@patch("pato.crud.sessions.os.path.isdir", new=lambda _: False)
+def test_dir_does_not_exist(_, mock_permissions, client):
+    """Should return 500 if directory does not exist"""
+    resp = client.post(
+        "/proposals/cm31111/sessions/5/initialModel",
+        files={"file": ("mrc.mrc", VALID_FILE, "application/octet-stream")},
+    )
+
+    assert resp.status_code == 500


### PR DESCRIPTION
**JIRA ticket**: [LIMS-1761][(https://jira.diamond.ac.uk/browse/LIMS-1761)

**Summary**:

To further improve 3D classification models, users should be able to provide a low-res initial model to act as a starting point for building these classes.

This allows users to upload initial models which are dropped in the visit folder.

**Changes**:

- Add initial model uploads

**To test**:

Assuming you've mounted /dls and you're using the local development DB

- Send a POST request to `/proposals/cm31111/sessions/5/initialModel` with [image.mrc.zip](https://github.com/user-attachments/files/22410251/image.mrc.zip) as the body (unzipped), check if the image is deposited in the visit directory for cm31111-5
- Send a POST request to `/proposals/cm31111/sessions/5/initialModel` with [broken.mrc.zip](https://github.com/user-attachments/files/22410265/broken.mrc.zip) as the body (unzipped), check if a 415 is returned (invalid file type)
- Send a POST request to `/proposals/cm31111/sessions/5/initialModel` with any non-MRC file, check if 415 is returned
