### PR TITLE
[LIMS-2099] Return cassette position for data collection group

### DIFF
--- a/src/pato/crud/groups.py
+++ b/src/pato/crud/groups.py
@@ -5,6 +5,7 @@ from lims_utils.auth import GenericUser
 from lims_utils.models import Paged, ProposalReference
 from lims_utils.tables import (
     Atlas,
+    BLSample,
     BLSession,
     DataCollection,
     DataCollectionGroup,
@@ -50,6 +51,7 @@ def get_collection_groups(
             ExperimentType.name.label("experimentTypeName"),
             Atlas.atlasId,
             DataCollection.imageDirectory,
+            BLSample.subLocation.label("cassettePosition"),
             f.count(DataCollection.dataCollectionId.distinct()).label("collections"),
         )
         .select_from(DataCollectionGroup)
@@ -57,6 +59,7 @@ def get_collection_groups(
         .join(ExperimentType, isouter=True)
         .join(BLSession)
         .join(Proposal)
+        .join(BLSample, BLSample.blSampleId == DataCollectionGroup.blSampleId, isouter=True)
         .join(DataCollection, isouter=True)
         .filter(
             Proposal.proposalCode == proposal_reference.code,

--- a/src/pato/models/response.py
+++ b/src/pato/models/response.py
@@ -85,6 +85,7 @@ class DataCollectionGroupSummaryResponse(OrmBaseModel):
     experimentTypeName: Optional[str] = "Single Particle"
     imageDirectory: Optional[str] = None
     comments: Optional[str] = None
+    cassettePosition: Optional[int] = None
     collections: int
 
     @field_validator("experimentTypeName")


### PR DESCRIPTION
**JIRA ticket**: [LIMS-2099](https://jira.diamond.ac.uk/browse/LIMS-2099)

**Summary**:

Since more data is being inserted into SCAUP, more DCGs have cassette positions associated with them. Since the comments column is not being used all that often, it would be useful to replace it with the cassette position

**Changes**:

- Return cassette position for data collection group

**To test**:

Assuming you have ispyb-restore mounted:

- Send a GET request to https://local-oidc-test.diamond.ac.uk:9000/api/proposals/bi37584/sessions/8/dataGroups?page=0&limit=20&search=, check if both items have cassette positions associated with them