### PR TITLE
Send alignment quality of tomograms plus tilt angle step to frontend

### DIFF
--- a/src/pato/models/collections.py
+++ b/src/pato/models/collections.py
@@ -143,7 +143,7 @@ class DataCollectionSummary(BaseDataCollectionOut):
     @model_validator(mode="after")
     def axis_step(self):
         if self.axisEnd and self.axisStart and self.numberOfImages:
-            self.axisStep = (self.axisEnd - self.axisStart) / self.numberOfImages
+            self.axisStep = round((self.axisEnd - self.axisStart) / self.numberOfImages, 2)
         return self
 
 

--- a/src/pato/models/collections.py
+++ b/src/pato/models/collections.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Literal, Optional
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, computed_field, field_validator
 
 from .response import OrmBaseModel
 
@@ -51,10 +51,6 @@ class DataCollectionSummary(BaseDataCollectionOut):
         None,
         description="Pixel size on image, calculated from magnification",
     )
-    pixelSizeNanometers: Optional[float] = Field(
-        None,
-        description="Pixel size on image, converted to nm",
-    )
     voltage: Optional[float] = None
     imageSizeX: Optional[int] = Field(
         None,
@@ -67,7 +63,6 @@ class DataCollectionSummary(BaseDataCollectionOut):
     axisStart: Optional[float] = None
     axisEnd: Optional[float] = None
     axisRange: Optional[float] = None
-    axisStep: Optional[float] = None
     overlap: Optional[float] = None
     numberOfImages: Optional[int] = None
     startImageNumber: Optional[int] = None
@@ -134,17 +129,17 @@ class DataCollectionSummary(BaseDataCollectionOut):
     def to_angstrom(cls, v):
         return v if v is None else v * 10
 
-    @model_validator(mode="after")
-    def to_nanometers(self):
-        if self.pixelSizeOnImage:
-            self.pixelSizeNanometers = self.pixelSizeOnImage / 10
-        return self
+    @computed_field
+    def pixelSizeNanometers(self) -> float | None:
+        """Pixel size on image, converted to nm"""
+        return self.pixelSizeOnImage / 10 if self.pixelSizeOnImage else None
 
-    @model_validator(mode="after")
-    def axis_step(self):
+    @computed_field
+    def axisStep(self) -> float | None:
+        """Angle step for tilt series"""
         if self.axisEnd and self.axisStart and self.numberOfImages:
-            self.axisStep = round((self.axisEnd - self.axisStart) / self.numberOfImages, 2)
-        return self
+            return round((self.axisEnd - self.axisStart) / self.numberOfImages, 2)
+        return None
 
 
 # mypy doesn't support type aliases yet

--- a/src/pato/models/collections.py
+++ b/src/pato/models/collections.py
@@ -136,7 +136,8 @@ class DataCollectionSummary(BaseDataCollectionOut):
 
     @model_validator(mode="after")
     def to_nanometers(self):
-        self.pixelSizeNanometers = self.pixelSizeOnImage / 10
+        if self.pixelSizeOnImage:
+            self.pixelSizeNanometers = self.pixelSizeOnImage / 10
         return self
 
     @model_validator(mode="after")

--- a/src/pato/models/collections.py
+++ b/src/pato/models/collections.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Literal, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from .response import OrmBaseModel
 
@@ -51,6 +51,10 @@ class DataCollectionSummary(BaseDataCollectionOut):
         None,
         description="Pixel size on image, calculated from magnification",
     )
+    pixelSizeNanometers: Optional[float] = Field(
+        None,
+        description="Pixel size on image, converted to nm",
+    )
     voltage: Optional[float] = None
     imageSizeX: Optional[int] = Field(
         None,
@@ -63,6 +67,7 @@ class DataCollectionSummary(BaseDataCollectionOut):
     axisStart: Optional[float] = None
     axisEnd: Optional[float] = None
     axisRange: Optional[float] = None
+    axisStep: Optional[float] = None
     overlap: Optional[float] = None
     numberOfImages: Optional[int] = None
     startImageNumber: Optional[int] = None
@@ -128,6 +133,17 @@ class DataCollectionSummary(BaseDataCollectionOut):
     @field_validator("pixelSizeOnImage")
     def to_angstrom(cls, v):
         return v if v is None else v * 10
+
+    @model_validator(mode="after")
+    def to_nanometers(cls, values):
+        values.pixelSizeNanometers = values.pixelSizeOnImage / 10
+        return values
+
+    @model_validator(mode="after")
+    def axis_step(cls, values):
+        if values.axisEnd and values.axisStart and values.numberOfImages:
+            values.axisStep = (values.axisEnd - values.axisStart) / values.numberOfImages
+        return values
 
 
 # mypy doesn't support type aliases yet

--- a/src/pato/models/collections.py
+++ b/src/pato/models/collections.py
@@ -135,15 +135,15 @@ class DataCollectionSummary(BaseDataCollectionOut):
         return v if v is None else v * 10
 
     @model_validator(mode="after")
-    def to_nanometers(cls, values):
-        values.pixelSizeNanometers = values.pixelSizeOnImage / 10
-        return values
+    def to_nanometers(self):
+        self.pixelSizeNanometers = self.pixelSizeOnImage / 10
+        return self
 
     @model_validator(mode="after")
-    def axis_step(cls, values):
-        if values.axisEnd and values.axisStart and values.numberOfImages:
-            values.axisStep = (values.axisEnd - values.axisStart) / values.numberOfImages
-        return values
+    def axis_step(self):
+        if self.axisEnd and self.axisStart and self.numberOfImages:
+            self.axisStep = (self.axisEnd - self.axisStart) / self.numberOfImages
+        return self
 
 
 # mypy doesn't support type aliases yet

--- a/src/pato/models/response.py
+++ b/src/pato/models/response.py
@@ -267,6 +267,7 @@ class TomogramResponse(OrmBaseModel):
     tiltAngleOffset: Optional[float] = None
     zShift: Optional[float] = None
     refinedTiltAxis: Optional[float] = None
+    globalAlignmentQuality: Optional[float] = None
 
 
 class TomogramFullResponse(ProcessingJobResponse):


### PR DESCRIPTION
**Summary**:

Allow the alignment quality to be displayed in the tomogram alignment frontend display, and also send the pixel size in nm and the angle step between tilts.

**Changes**:

- Add alignment quality to tomogram response model
- Add method to store pixel size in nm as well as Angstroms
- Add method to find the tilt angle step

**To test**:

- Needs frontend on branch `feature/b24-page`
- Go to https://local-oidc-test.diamond.ac.uk:9000/proposals/bi40959/sessions/38/groups/18815831/tomograms/1 and check global alignment quality is displayed in the alignment table, and that the pixel size and angle step are displayed in the collection parameters table
